### PR TITLE
Add exclusion for iOS-specific code for tvOS

### DIFF
--- a/src/gpu/ganesh/mtl/GrMtlCaps.mm
+++ b/src/gpu/ganesh/mtl/GrMtlCaps.mm
@@ -96,7 +96,7 @@ bool GrMtlCaps::getGPUFamilyFromFeatureSet(id<MTLDevice> device,
             return true;
         }
     }
-#elif defined(SK_BUILD_FOR_IOS)
+#elif defined(SK_BUILD_FOR_IOS) || !defined(SK_BUILD_FOR_TVOS)
     // TODO: support tvOS
    *gpuFamily = GPUFamily::kApple;
     // iOS 12

--- a/src/gpu/ganesh/mtl/GrMtlCaps.mm
+++ b/src/gpu/ganesh/mtl/GrMtlCaps.mm
@@ -96,7 +96,7 @@ bool GrMtlCaps::getGPUFamilyFromFeatureSet(id<MTLDevice> device,
             return true;
         }
     }
-#elif defined(SK_BUILD_FOR_IOS) || !defined(SK_BUILD_FOR_TVOS)
+#elif defined(SK_BUILD_FOR_IOS) && !defined(SK_BUILD_FOR_TVOS)
     // TODO: support tvOS
    *gpuFamily = GPUFamily::kApple;
     // iOS 12


### PR DESCRIPTION
Basically, Skia treats tvOS as iOS with a different SDK and all works fine if I can skip this block. For proper Metal we will need min tvOS version to be 14 anyway, and thus this piece of code is irrelevant, it is needed to support older OSes with MTLFeatureSet while newer use MTLGPUFamily, and it works fine on tvOS 14+.

The easiest way to do this would be to add SK_BUILD_FOR_TVOS in build scripts and apply this change. 