### PR TITLE
Fix `FontRastrSettings` caching

### DIFF
--- a/modules/skparagraph/include/FontRastrSettings.h
+++ b/modules/skparagraph/include/FontRastrSettings.h
@@ -9,15 +9,15 @@ namespace skia {
 namespace textlayout {
 
 struct FontRastrSettings {
-    FontRastrSettings() {
-        fEdging = SkFont::Edging::kAntiAlias;
-        fHinting = SkFontHinting::kSlight;
-        fSubpixel = true;
-    }
 
-    SkFont::Edging fEdging;
-    SkFontHinting fHinting;
-    bool fSubpixel;
+    /** Whether edge pixels draw opaque or with partial transparency. */
+    SkFont::Edging fEdging = SkFont::Edging::kAntiAlias;
+
+    /** Level of glyph outline adjustment. */
+    SkFontHinting fHinting = SkFontHinting::kSlight;
+
+    /** Whether glyphs respect sub-pixel positioning. */
+    bool fSubpixel = true;
 };
 
 

--- a/modules/skparagraph/include/ParagraphStyle.h
+++ b/modules/skparagraph/include/ParagraphStyle.h
@@ -112,7 +112,7 @@ struct ParagraphStyle {
     void setStrutStyle(StrutStyle strutStyle) { fStrutStyle = std::move(strutStyle); }
 
     const FontRastrSettings& getFontRastrSettings() const { return fFontRastrSettings; }
-    void setFontRastrSettings(FontRastrSettings fontRastrSettings) { fFontRastrSettings = fontRastrSettings; }
+    void setFontRastrSettings(const FontRastrSettings& fontRastrSettings) { fFontRastrSettings = fontRastrSettings; }
 
     const TextStyle& getTextStyle() const { return fDefaultTextStyle; }
     void setTextStyle(const TextStyle& textStyle) { fDefaultTextStyle = textStyle; }

--- a/modules/skparagraph/include/TextStyle.h
+++ b/modules/skparagraph/include/TextStyle.h
@@ -278,7 +278,7 @@ public:
     void setTypeface(sk_sp<SkTypeface> typeface) { fTypeface = std::move(typeface); }
 
     const FontRastrSettings& getFontRastrSettings() const { return fFontRastrSettings; }
-    void setFontRastrSettings(FontRastrSettings fontRastrSettings) { fFontRastrSettings = fontRastrSettings; }
+    void setFontRastrSettings(const FontRastrSettings& fontRastrSettings) { fFontRastrSettings = fontRastrSettings; }
 
     SkString getLocale() const { return fLocale; }
     void setLocale(const SkString& locale) { fLocale = locale; }

--- a/modules/skparagraph/src/ParagraphCache.cpp
+++ b/modules/skparagraph/src/ParagraphCache.cpp
@@ -145,6 +145,11 @@ uint32_t ParagraphCacheKey::computeHash() const {
     hash = mix(hash, SkGoodHash()(fParagraphStyle.getTextDirection()));
     hash = mix(hash, SkGoodHash()(fParagraphStyle.getReplaceTabCharacters() ? 1 : 0));
 
+    auto& fontRastrSettings = fParagraphStyle.getFontRastrSettings();
+    hash = mix(hash, SkGoodHash()(fontRastrSettings.fEdging));
+    hash = mix(hash, SkGoodHash()(fontRastrSettings.fHinting));
+    hash = mix(hash, SkGoodHash()(fontRastrSettings.fSubpixel ? 1 : 0));
+
     auto& strutStyle = fParagraphStyle.getStrutStyle();
     if (strutStyle.getStrutEnabled()) {
         hash = mix(hash, SkGoodHash()(relax(strutStyle.getHeight())));


### PR DESCRIPTION
- Add `FontRastrSettings` into cache key hash calculation
- Default values instead of constructor - unlocks initialization via curly-braces syntax
- Const references in setters to avoid extra copys

Also updated the sample page to compare all modes + magnified via RTT

Fixes https://youtrack.jetbrains.com/issue/CMP-5638

Before | After
---|---
<img width="1392" alt="Screenshot 2024-09-13 at 16 46 06" src="https://github.com/user-attachments/assets/1eb96b9c-a8dd-44b9-8d50-7aad36ad3b6c"> | <img width="1348" alt="Screenshot 2024-09-13 at 16 47 09" src="https://github.com/user-attachments/assets/9cf8ec32-6db3-4998-b37f-cfd48a568e33">
