### PR TITLE
Support top ratio based vertical alignment

### DIFF
--- a/modules/skparagraph/include/FontRastrSettings.h
+++ b/modules/skparagraph/include/FontRastrSettings.h
@@ -18,6 +18,12 @@ struct FontRastrSettings {
 
     /** Whether glyphs respect sub-pixel positioning. */
     bool fSubpixel = true;
+
+    bool operator==(const FontRastrSettings& rhs) const {
+        return this->fEdging == rhs.fEdging &&
+               this->fHinting == rhs.fHinting &&
+               this->fSubpixel == rhs.fSubpixel;
+    }
 };
 
 

--- a/modules/skparagraph/include/ParagraphStyle.h
+++ b/modules/skparagraph/include/ParagraphStyle.h
@@ -46,14 +46,17 @@ struct StrutStyle {
     bool getHeightOverride() const { return fHeightOverride; }
     void setHeightOverride(bool v) { fHeightOverride = v; }
 
-    void setHalfLeading(bool halfLeading) { fHalfLeading = halfLeading; }
-    bool getHalfLeading() const { return fHalfLeading; }
+    void setHalfLeading(bool halfLeading) { fTopRatio = halfLeading ? 0.5f : -1.0f; }
+    bool getHalfLeading() const { return fTopRatio == 0.5f; }
+
+    void setTopRatio(SkScalar topRatio) { fTopRatio = topRatio; }
+    SkScalar getTopRatio() const { return fTopRatio; }
 
     bool operator==(const StrutStyle& rhs) const {
         return this->fEnabled == rhs.fEnabled &&
                this->fHeightOverride == rhs.fHeightOverride &&
                this->fForceHeight == rhs.fForceHeight &&
-               this->fHalfLeading == rhs.fHalfLeading &&
+               this->fTopRatio == rhs.fTopRatio &&
                nearlyEqual(this->fLeading, rhs.fLeading) &&
                nearlyEqual(this->fHeight, rhs.fHeight) &&
                nearlyEqual(this->fFontSize, rhs.fFontSize) &&
@@ -71,9 +74,9 @@ private:
     bool fForceHeight;
     bool fEnabled;
     bool fHeightOverride;
-    // true: half leading.
-    // false: scale ascent/descent with fHeight.
-    bool fHalfLeading;
+    // [0..1]: the ratio of ascent to ascent+descent
+    // -1: proportional to the ascent/descent
+    SkScalar fTopRatio;
 };
 
 struct TextIndent {

--- a/modules/skparagraph/include/ParagraphStyle.h
+++ b/modules/skparagraph/include/ParagraphStyle.h
@@ -53,30 +53,29 @@ struct StrutStyle {
     SkScalar getTopRatio() const { return fTopRatio; }
 
     bool operator==(const StrutStyle& rhs) const {
-        return this->fEnabled == rhs.fEnabled &&
-               this->fHeightOverride == rhs.fHeightOverride &&
-               this->fForceHeight == rhs.fForceHeight &&
-               this->fTopRatio == rhs.fTopRatio &&
-               nearlyEqual(this->fLeading, rhs.fLeading) &&
-               nearlyEqual(this->fHeight, rhs.fHeight) &&
-               nearlyEqual(this->fFontSize, rhs.fFontSize) &&
+        return this->fFontFamilies == rhs.fFontFamilies &&
                this->fFontStyle == rhs.fFontStyle &&
-               this->fFontFamilies == rhs.fFontFamilies;
+               nearlyEqual(this->fFontSize, rhs.fFontSize) &&
+               nearlyEqual(this->fHeight, rhs.fHeight) &&
+               nearlyEqual(this->fLeading, rhs.fLeading) &&
+               nearlyEqual(this->fTopRatio, rhs.fTopRatio) &&
+               this->fForceHeight == rhs.fForceHeight &&
+               this->fEnabled == rhs.fEnabled &&
+               this->fHeightOverride == rhs.fHeightOverride;
     }
 
 private:
-
     std::vector<SkString> fFontFamilies;
     SkFontStyle fFontStyle;
     SkScalar fFontSize;
     SkScalar fHeight;
     SkScalar fLeading;
-    bool fForceHeight;
-    bool fEnabled;
-    bool fHeightOverride;
     // [0..1]: the ratio of ascent to ascent+descent
     // -1: proportional to the ascent/descent
     SkScalar fTopRatio;
+    bool fForceHeight;
+    bool fEnabled;
+    bool fHeightOverride;
 };
 
 struct TextIndent {
@@ -102,13 +101,20 @@ struct ParagraphStyle {
     ParagraphStyle();
 
     bool operator==(const ParagraphStyle& rhs) const {
-        return this->fHeight == rhs.fHeight &&
-               this->fEllipsis == rhs.fEllipsis &&
-               this->fEllipsisUtf16 == rhs.fEllipsisUtf16 &&
-               this->fTextDirection == rhs.fTextDirection && this->fTextAlign == rhs.fTextAlign &&
+        return this->fStrutStyle == rhs.fStrutStyle &&
                this->fDefaultTextStyle == rhs.fDefaultTextStyle &&
+               this->fTextAlign == rhs.fTextAlign &&
+               this->fTextDirection == rhs.fTextDirection &&
+               this->fLinesLimit == rhs.fLinesLimit &&
+               this->fEllipsisUtf16 == rhs.fEllipsisUtf16 &&
+               this->fEllipsis == rhs.fEllipsis &&
+               this->fHeight == rhs.fHeight &&
+               this->fTextHeightBehavior == rhs.fTextHeightBehavior &&
                this->fTextIndent == rhs.fTextIndent &&
-               this->fReplaceTabCharacters == rhs.fReplaceTabCharacters;
+               this->fFontRastrSettings == rhs.fFontRastrSettings &&
+               this->fHintingIsOn == rhs.fHintingIsOn &&
+               this->fReplaceTabCharacters == rhs.fReplaceTabCharacters &&
+               this->fApplyRoundingHack == rhs.fApplyRoundingHack;
     }
 
     const StrutStyle& getStrutStyle() const { return fStrutStyle; }
@@ -167,11 +173,11 @@ private:
     SkString fEllipsis;
     SkScalar fHeight;
     TextHeightBehavior fTextHeightBehavior;
+    TextIndent fTextIndent;
+    FontRastrSettings fFontRastrSettings;
     bool fHintingIsOn;
     bool fReplaceTabCharacters;
     bool fApplyRoundingHack = true;
-    TextIndent fTextIndent;
-    FontRastrSettings fFontRastrSettings;
 };
 }  // namespace textlayout
 }  // namespace skia

--- a/modules/skparagraph/include/TextStyle.h
+++ b/modules/skparagraph/include/TextStyle.h
@@ -264,8 +264,11 @@ public:
     void setHeightOverride(bool heightOverride) { fHeightOverride = heightOverride; }
     bool getHeightOverride() const { return fHeightOverride; }
 
-    void setHalfLeading(bool halfLeading) { fHalfLeading = halfLeading; }
-    bool getHalfLeading() const { return fHalfLeading; }
+    void setHalfLeading(bool halfLeading) { fTopRatio = halfLeading ? 0.5f : -1.0f; }
+    bool getHalfLeading() const { return fTopRatio == 0.5f; }
+
+    void setTopRatio(SkScalar topRatio) { fTopRatio = topRatio; }
+    SkScalar getTopRatio() const { return fTopRatio; }
 
     void setLetterSpacing(SkScalar letterSpacing) { fLetterSpacing = letterSpacing; }
     SkScalar getLetterSpacing() const { return fLetterSpacing; }
@@ -312,9 +315,9 @@ private:
     SkScalar fHeight = 1.0;
     bool fHeightOverride = false;
     SkScalar fBaselineShift = 0.0f;
-    // true: half leading.
-    // false: scale ascent/descent with fHeight.
-    bool fHalfLeading = false;
+    // [0..1]: the ratio of ascent to ascent+descent
+    // -1: proportional to the ascent/descent
+    SkScalar fTopRatio = -1.0f;
     SkString fLocale = {};
     SkScalar fLetterSpacing = 0.0;
     SkScalar fWordSpacing = 0.0;

--- a/modules/skparagraph/src/OneLineShaper.cpp
+++ b/modules/skparagraph/src/OneLineShaper.cpp
@@ -210,7 +210,7 @@ void OneLineShaper::finish(const Block& block, SkScalar height, SkScalar& advanc
                     info,
                     run->fClusterStart,
                     height,
-                    block.fStyle.getHalfLeading(),
+                    block.fStyle.getTopRatio(),
                     block.fStyle.getBaselineShift(),
                     this->fParagraph->fRuns.size(),
                     advanceX
@@ -639,7 +639,7 @@ bool OneLineShaper::shape() {
 
             // Start from the beginning (hoping that it's a simple case one block - one run)
             fHeight = block.fStyle.getHeightOverride() ? block.fStyle.getHeight() : 0;
-            fUseHalfLeading = block.fStyle.getHalfLeading();
+            fTopRatio = block.fStyle.getTopRatio();
             fBaselineShift = block.fStyle.getBaselineShift();
             fAdvance = SkVector::Make(advanceX, 0);
             fCurrentText = block.fRange;

--- a/modules/skparagraph/src/OneLineShaper.h
+++ b/modules/skparagraph/src/OneLineShaper.h
@@ -18,7 +18,7 @@ public:
     explicit OneLineShaper(ParagraphImpl* paragraph)
         : fParagraph(paragraph)
         , fHeight(0.0f)
-        , fUseHalfLeading(false)
+        , fTopRatio(-1.0f)
         , fBaselineShift(0.0f)
         , fAdvance(SkPoint::Make(0.0f, 0.0f))
         , fUnresolvedGlyphs(0)
@@ -93,7 +93,7 @@ private:
                                            info,
                                            fCurrentText.start,
                                            fHeight,
-                                           fUseHalfLeading,
+                                           fTopRatio,
                                            fBaselineShift,
                                            ++fUniqueRunId,
                                            fAdvance.fX);
@@ -115,7 +115,7 @@ private:
     ParagraphImpl* fParagraph;
     TextRange fCurrentText;
     SkScalar fHeight;
-    bool fUseHalfLeading;
+    SkScalar fTopRatio;
     SkScalar fBaselineShift;
     SkVector fAdvance;
     size_t fUnresolvedGlyphs;

--- a/modules/skparagraph/src/ParagraphCache.cpp
+++ b/modules/skparagraph/src/ParagraphCache.cpp
@@ -155,6 +155,7 @@ uint32_t ParagraphCacheKey::computeHash() const {
         hash = mix(hash, SkGoodHash()(relax(strutStyle.getHeight())));
         hash = mix(hash, SkGoodHash()(relax(strutStyle.getLeading())));
         hash = mix(hash, SkGoodHash()(relax(strutStyle.getFontSize())));
+        hash = mix(hash, SkGoodHash()(relax(strutStyle.getTopRatio())));
         hash = mix(hash, SkGoodHash()(strutStyle.getHeightOverride()));
         hash = mix(hash, SkGoodHash()(strutStyle.getFontStyle()));
         hash = mix(hash, SkGoodHash()(strutStyle.getForceStrutHeight()));

--- a/modules/skparagraph/src/ParagraphCache.cpp
+++ b/modules/skparagraph/src/ParagraphCache.cpp
@@ -123,21 +123,23 @@ uint32_t ParagraphCacheKey::computeHash() const {
         if (ts.fStyle.isPlaceholder()) {
             continue;
         }
-        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getLetterSpacing())));
-        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getWordSpacing())));
-        hash = mix(hash, SkGoodHash()(ts.fStyle.getLocale()));
-        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getHeight())));
-        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getBaselineShift())));
+        hash = mix(hash, SkGoodHash()(ts.fStyle.getFontStyle()));
         for (auto& ff : ts.fStyle.getFontFamilies()) {
             hash = mix(hash, SkGoodHash()(ff));
         }
+        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getFontSize())));
+        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getHeight())));
+        hash = mix(hash, SkGoodHash()(ts.fStyle.getHeightOverride() ? 1 : 0));
+        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getBaselineShift())));
+        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getTopRatio())));
+        hash = mix(hash, SkGoodHash()(ts.fStyle.getLocale()));
+        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getLetterSpacing())));
+        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getWordSpacing())));
         for (auto& ff : ts.fStyle.getFontFeatures()) {
             hash = mix(hash, SkGoodHash()(ff.fValue));
             hash = mix(hash, SkGoodHash()(ff.fName));
         }
         hash = mix(hash, std::hash<std::optional<FontArguments>>()(ts.fStyle.getFontArguments()));
-        hash = mix(hash, SkGoodHash()(ts.fStyle.getFontStyle()));
-        hash = mix(hash, SkGoodHash()(relax(ts.fStyle.getFontSize())));
         hash = mix(hash, SkGoodHash()(ts.fRange));
     }
 
@@ -187,18 +189,8 @@ bool ParagraphCacheKey::operator==(const ParagraphCacheKey& other) const {
     }
 
     // There is no need to compare default paragraph styles - they are included into fTextStyles
-    if (!exactlyEqual(fParagraphStyle.getHeight(), other.fParagraphStyle.getHeight())) {
-        return false;
-    }
-    if (fParagraphStyle.getTextDirection() != other.fParagraphStyle.getTextDirection()) {
-        return false;
-    }
 
-    if (!(fParagraphStyle.getStrutStyle() == other.fParagraphStyle.getStrutStyle())) {
-        return false;
-    }
-
-    if (!(fParagraphStyle.getReplaceTabCharacters() == other.fParagraphStyle.getReplaceTabCharacters())) {
+    if (!(fParagraphStyle == other.fParagraphStyle)) {
         return false;
     }
 

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -707,12 +707,13 @@ void ParagraphImpl::resolveStrut() {
     if (strutStyle.getHeightOverride()) {
         SkScalar strutAscent = 0.0f;
         SkScalar strutDescent = 0.0f;
-        // The half leading flag doesn't take effect unless there's height override.
-        if (strutStyle.getHalfLeading()) {
+        // The top ratio doesn't take effect unless there's height override.
+        SkScalar topRatio = strutStyle.getTopRatio();
+        if (topRatio >= 0.0f && topRatio <= 1.0f) {
             const auto occupiedHeight = metrics.fDescent - metrics.fAscent;
             auto flexibleHeight = strutStyle.getHeight() * strutStyle.getFontSize() - occupiedHeight;
             // Distribute the flexible height evenly over and under.
-            flexibleHeight /= 2;
+            flexibleHeight *= topRatio;
             strutAscent = metrics.fAscent - flexibleHeight;
             strutDescent = metrics.fDescent + flexibleHeight;
         } else {
@@ -1036,11 +1037,13 @@ void ParagraphImpl::computeEmptyMetrics() {
         textStyle.getHeightOverride()) {
         const auto intrinsicHeight = fEmptyMetrics.height();
         const auto strutHeight = textStyle.getHeight() * textStyle.getFontSize();
-        if (paragraphStyle().getStrutStyle().getHalfLeading()) {
+        SkScalar topRatio = paragraphStyle().getStrutStyle().getTopRatio();
+        if (topRatio >= 0.0f && topRatio <= 1.0f) {
+            const auto extraLeading = (strutHeight - intrinsicHeight) * topRatio;
             fEmptyMetrics.update(
-                fEmptyMetrics.ascent(),
-                fEmptyMetrics.descent(),
-                fEmptyMetrics.leading() + strutHeight - intrinsicHeight);
+                fEmptyMetrics.ascent() - extraLeading,
+                fEmptyMetrics.descent() + extraLeading,
+                fEmptyMetrics.leading() + extraLeading * 2.0f);
         } else {
             const auto multiplier = strutHeight / intrinsicHeight;
             fEmptyMetrics.update(

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -712,10 +712,8 @@ void ParagraphImpl::resolveStrut() {
         if (topRatio >= 0.0f && topRatio <= 1.0f) {
             const auto occupiedHeight = metrics.fDescent - metrics.fAscent;
             auto flexibleHeight = strutStyle.getHeight() * strutStyle.getFontSize() - occupiedHeight;
-            // Distribute the flexible height evenly over and under.
-            flexibleHeight *= topRatio;
-            strutAscent = metrics.fAscent - flexibleHeight;
-            strutDescent = metrics.fDescent + flexibleHeight;
+            strutAscent = metrics.fAscent - flexibleHeight * topRatio;
+            strutDescent = metrics.fDescent + flexibleHeight * (1.0f - topRatio);
         } else {
             const SkScalar strutMetricsHeight = metrics.fDescent - metrics.fAscent + metrics.fLeading;
             const auto strutHeightMultiplier = strutMetricsHeight == 0
@@ -1039,11 +1037,11 @@ void ParagraphImpl::computeEmptyMetrics() {
         const auto strutHeight = textStyle.getHeight() * textStyle.getFontSize();
         SkScalar topRatio = paragraphStyle().getStrutStyle().getTopRatio();
         if (topRatio >= 0.0f && topRatio <= 1.0f) {
-            const auto extraLeading = (strutHeight - intrinsicHeight) * topRatio;
+            const auto extraLeading = strutHeight - intrinsicHeight;
             fEmptyMetrics.update(
-                fEmptyMetrics.ascent() - extraLeading,
-                fEmptyMetrics.descent() + extraLeading,
-                fEmptyMetrics.leading() + extraLeading * 2.0f);
+                fEmptyMetrics.ascent() - extraLeading * topRatio,
+                fEmptyMetrics.descent() + extraLeading * (1.0f - topRatio),
+                fEmptyMetrics.leading() + extraLeading);
         } else {
             const auto multiplier = strutHeight / intrinsicHeight;
             fEmptyMetrics.update(

--- a/modules/skparagraph/src/ParagraphStyle.cpp
+++ b/modules/skparagraph/src/ParagraphStyle.cpp
@@ -15,7 +15,7 @@ StrutStyle::StrutStyle() {
     fLeading = -1;
     fForceHeight = false;
     fHeightOverride = false;
-    fHalfLeading = false;
+    fTopRatio = -1.0f;
     fEnabled = false;
 }
 

--- a/modules/skparagraph/src/Run.cpp
+++ b/modules/skparagraph/src/Run.cpp
@@ -18,7 +18,7 @@ Run::Run(ParagraphImpl* owner,
          const SkShaper::RunHandler::RunInfo& info,
          size_t firstChar,
          SkScalar heightMultiplier,
-         bool useHalfLeading,
+         SkScalar topRatio,
          SkScalar baselineShift,
          size_t index,
          SkScalar offsetX)
@@ -33,7 +33,7 @@ Run::Run(ParagraphImpl* owner,
     , fOffsets(fGlyphData->offsets)
     , fClusterIndexes(fGlyphData->clusterIndexes)
     , fHeightMultiplier(heightMultiplier)
-    , fUseHalfLeading(useHalfLeading)
+    , fTopRatio(topRatio)
     , fBaselineShift(baselineShift)
 {
     fBidiLevel = info.fBidiLevel;
@@ -67,8 +67,8 @@ void Run::calculateMetrics() {
     }
     const auto runHeight = fHeightMultiplier * fFont.getSize();
     const auto fontIntrinsicHeight = fCorrectDescent - fCorrectAscent;
-    if (fUseHalfLeading) {
-        const auto extraLeading = (runHeight - fontIntrinsicHeight) / 2;
+    if (fTopRatio >= 0.0f && fTopRatio <= 1.0f) {
+        const auto extraLeading = (runHeight - fontIntrinsicHeight) * fTopRatio;
         fCorrectAscent -= extraLeading;
         fCorrectDescent += extraLeading;
     } else {

--- a/modules/skparagraph/src/Run.cpp
+++ b/modules/skparagraph/src/Run.cpp
@@ -68,9 +68,9 @@ void Run::calculateMetrics() {
     const auto runHeight = fHeightMultiplier * fFont.getSize();
     const auto fontIntrinsicHeight = fCorrectDescent - fCorrectAscent;
     if (fTopRatio >= 0.0f && fTopRatio <= 1.0f) {
-        const auto extraLeading = (runHeight - fontIntrinsicHeight) * fTopRatio;
-        fCorrectAscent -= extraLeading;
-        fCorrectDescent += extraLeading;
+        const auto extraLeading = runHeight - fontIntrinsicHeight;
+        fCorrectAscent -= extraLeading * fTopRatio;
+        fCorrectDescent += extraLeading * (1.0f - fTopRatio);
     } else {
         const auto multiplier = runHeight / fontIntrinsicHeight;
         fCorrectAscent *= multiplier;

--- a/modules/skparagraph/src/Run.h
+++ b/modules/skparagraph/src/Run.h
@@ -58,7 +58,7 @@ public:
         const SkShaper::RunHandler::RunInfo& info,
         size_t firstChar,
         SkScalar heightMultiplier,
-        bool useHalfLeading,
+        SkScalar topRatio,
         SkScalar baselineShift,
         size_t index,
         SkScalar shiftX);
@@ -97,7 +97,7 @@ public:
     TextDirection getTextDirection() const { return leftToRight() ? TextDirection::kLtr : TextDirection::kRtl; }
     size_t index() const { return fIndex; }
     SkScalar heightMultiplier() const { return fHeightMultiplier; }
-    bool useHalfLeading() const { return fUseHalfLeading; }
+    SkScalar topRatio() const { return fTopRatio; }
     SkScalar baselineShift() const { return fBaselineShift; }
     PlaceholderStyle* placeholderStyle() const;
     bool isPlaceholder() const { return fPlaceholderIndex != std::numeric_limits<size_t>::max(); }
@@ -204,7 +204,7 @@ private:
 
     SkFontMetrics fFontMetrics;
     const SkScalar fHeightMultiplier;
-    const bool fUseHalfLeading;
+    const SkScalar fTopRatio;
     const SkScalar fBaselineShift;
     SkScalar fCorrectAscent;
     SkScalar fCorrectDescent;

--- a/modules/skparagraph/src/TextLine.cpp
+++ b/modules/skparagraph/src/TextLine.cpp
@@ -643,8 +643,8 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
 
     class ShapeHandler final : public SkShaper::RunHandler {
     public:
-        ShapeHandler(SkScalar lineHeight, bool useHalfLeading, SkScalar baselineShift, const SkString& ellipsis)
-            : fRun(nullptr), fLineHeight(lineHeight), fUseHalfLeading(useHalfLeading), fBaselineShift(baselineShift), fEllipsis(ellipsis) {}
+        ShapeHandler(SkScalar lineHeight, SkScalar topRatio, SkScalar baselineShift, const SkString& ellipsis)
+            : fRun(nullptr), fLineHeight(lineHeight), fTopRatio(topRatio), fBaselineShift(baselineShift), fEllipsis(ellipsis) {}
         std::unique_ptr<Run> run() & { return std::move(fRun); }
 
     private:
@@ -656,7 +656,7 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
 
         Buffer runBuffer(const RunInfo& info) override {
             SkASSERT(!fRun);
-            fRun = std::make_unique<Run>(nullptr, info, 0, fLineHeight, fUseHalfLeading, fBaselineShift, 0, 0);
+            fRun = std::make_unique<Run>(nullptr, info, 0, fLineHeight, fTopRatio, fBaselineShift, 0, 0);
             return fRun->newRunBuffer();
         }
 
@@ -671,7 +671,7 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
 
         std::unique_ptr<Run> fRun;
         SkScalar fLineHeight;
-        bool fUseHalfLeading;
+        SkScalar fTopRatio;
         SkScalar fBaselineShift;
         SkString fEllipsis;
     };
@@ -690,7 +690,7 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
     }
 
     auto shaped = [&](sk_sp<SkTypeface> typeface, sk_sp<SkFontMgr> fallback) -> std::unique_ptr<Run> {
-        ShapeHandler handler(run.heightMultiplier(), run.useHalfLeading(), run.baselineShift(), ellipsis);
+        ShapeHandler handler(run.heightMultiplier(), run.topRatio(), run.baselineShift(), ellipsis);
         SkFont font(std::move(typeface), textStyle.getFontSize());
         font.setEdging(SkFont::Edging::kAntiAlias);
         font.setHinting(SkFontHinting::kSlight);

--- a/modules/skparagraph/src/TextStyle.cpp
+++ b/modules/skparagraph/src/TextStyle.cpp
@@ -22,7 +22,7 @@ TextStyle TextStyle::cloneForPlaceholder() {
     result.fHeightOverride = fHeightOverride;
     result.fIsPlaceholder = true;
     result.fFontFeatures = fFontFeatures;
-    result.fHalfLeading = fHalfLeading;
+    result.fTopRatio = fTopRatio;
     result.fBaselineShift = fBaselineShift;
     result.fFontArguments = fFontArguments;
     return result;
@@ -58,7 +58,7 @@ bool TextStyle::equals(const TextStyle& other) const {
     if (fHeightOverride != other.fHeightOverride) {
         return false;
     }
-    if (fHalfLeading != other.fHalfLeading) {
+    if (fTopRatio != other.fTopRatio) {
         return false;
     }
     if (fBaselineShift != other.fBaselineShift) {
@@ -155,7 +155,7 @@ bool TextStyle::matchOneAttribute(StyleType styleType, const TextStyle& other) c
                    fFontFamilies == other.fFontFamilies &&
                    fFontSize == other.fFontSize &&
                    fHeight == other.fHeight &&
-                   fHalfLeading == other.fHalfLeading &&
+                   fTopRatio == other.fTopRatio &&
                    fBaselineShift == other.fBaselineShift &&
                    fFontArguments == other.fFontArguments;
         default:

--- a/modules/skparagraph/src/TextStyle.cpp
+++ b/modules/skparagraph/src/TextStyle.cpp
@@ -110,6 +110,7 @@ bool TextStyle::equalsByFonts(const TextStyle& that) const {
            nearlyEqual(fWordSpacing, that.fWordSpacing) &&
            nearlyEqual(fHeight, that.fHeight) &&
            nearlyEqual(fBaselineShift, that.fBaselineShift) &&
+           nearlyEqual(fTopRatio, that.fTopRatio) &&
            nearlyEqual(fFontSize, that.fFontSize) &&
            fLocale == that.fLocale;
 }


### PR DESCRIPTION
Support configurable vertical centering for implementing Compose's `LineHeightStyle.Alignment`.

https://youtrack.jetbrains.com/issue/CMP-2602

See also:
- https://github.com/JetBrains/skiko/pull/989
- https://github.com/JetBrains/compose-multiplatform-core/pull/1569
