### PR TITLE
Fix `ParagraphStyle` equals for layout cache

### DIFF
--- a/modules/skparagraph/include/ParagraphStyle.h
+++ b/modules/skparagraph/include/ParagraphStyle.h
@@ -100,22 +100,9 @@ private:
 struct ParagraphStyle {
     ParagraphStyle();
 
-    bool operator==(const ParagraphStyle& rhs) const {
-        return this->fStrutStyle == rhs.fStrutStyle &&
-               this->fDefaultTextStyle == rhs.fDefaultTextStyle &&
-               this->fTextAlign == rhs.fTextAlign &&
-               this->fTextDirection == rhs.fTextDirection &&
-               this->fLinesLimit == rhs.fLinesLimit &&
-               this->fEllipsisUtf16 == rhs.fEllipsisUtf16 &&
-               this->fEllipsis == rhs.fEllipsis &&
-               this->fHeight == rhs.fHeight &&
-               this->fTextHeightBehavior == rhs.fTextHeightBehavior &&
-               this->fTextIndent == rhs.fTextIndent &&
-               this->fFontRastrSettings == rhs.fFontRastrSettings &&
-               this->fHintingIsOn == rhs.fHintingIsOn &&
-               this->fReplaceTabCharacters == rhs.fReplaceTabCharacters &&
-               this->fApplyRoundingHack == rhs.fApplyRoundingHack;
-    }
+    bool equals(const ParagraphStyle& rhs) const;
+    bool equalsByLayout(const ParagraphStyle& rhs) const;
+    bool operator==(const ParagraphStyle& rhs) const { return this->equals(rhs); }
 
     const StrutStyle& getStrutStyle() const { return fStrutStyle; }
     void setStrutStyle(StrutStyle strutStyle) { fStrutStyle = std::move(strutStyle); }

--- a/modules/skparagraph/include/ParagraphStyle.h
+++ b/modules/skparagraph/include/ParagraphStyle.h
@@ -165,6 +165,9 @@ private:
     bool fHintingIsOn;
     bool fReplaceTabCharacters;
     bool fApplyRoundingHack = true;
+
+    // common part of equals and equalsByLayout
+    bool almostEquals(const ParagraphStyle& rhs) const;
 };
 }  // namespace textlayout
 }  // namespace skia

--- a/modules/skparagraph/src/ParagraphCache.cpp
+++ b/modules/skparagraph/src/ParagraphCache.cpp
@@ -22,10 +22,6 @@ namespace {
         }
     }
 
-    bool exactlyEqual(SkScalar x, SkScalar y) {
-        return x == y || (x != x && y != y);
-    }
-
 }  // namespace
 
 class ParagraphCacheKey {
@@ -187,8 +183,6 @@ bool ParagraphCacheKey::operator==(const ParagraphCacheKey& other) const {
     if (fTextStyles.size() != other.fTextStyles.size()) {
         return false;
     }
-
-    // There is no need to compare default paragraph styles - they are included into fTextStyles
 
     if (!fParagraphStyle.equalsByLayout(other.fParagraphStyle)) {
         return false;

--- a/modules/skparagraph/src/ParagraphCache.cpp
+++ b/modules/skparagraph/src/ParagraphCache.cpp
@@ -190,7 +190,7 @@ bool ParagraphCacheKey::operator==(const ParagraphCacheKey& other) const {
 
     // There is no need to compare default paragraph styles - they are included into fTextStyles
 
-    if (!(fParagraphStyle == other.fParagraphStyle)) {
+    if (!fParagraphStyle.equalsByLayout(other.fParagraphStyle)) {
         return false;
     }
 

--- a/modules/skparagraph/src/ParagraphStyle.cpp
+++ b/modules/skparagraph/src/ParagraphStyle.cpp
@@ -24,6 +24,41 @@ TextIndent::TextIndent() {
     fRestLine = 0.0;
 }
 
+
+bool ParagraphStyle::equals(const ParagraphStyle& rhs) const {
+    return this->fStrutStyle == rhs.fStrutStyle &&
+           this->fDefaultTextStyle == rhs.fDefaultTextStyle &&
+           this->fTextAlign == rhs.fTextAlign &&
+           this->fTextDirection == rhs.fTextDirection &&
+           this->fLinesLimit == rhs.fLinesLimit &&
+           this->fEllipsisUtf16 == rhs.fEllipsisUtf16 &&
+           this->fEllipsis == rhs.fEllipsis &&
+           this->fHeight == rhs.fHeight &&
+           this->fTextHeightBehavior == rhs.fTextHeightBehavior &&
+           this->fTextIndent == rhs.fTextIndent &&
+           this->fFontRastrSettings == rhs.fFontRastrSettings &&
+           this->fHintingIsOn == rhs.fHintingIsOn &&
+           this->fReplaceTabCharacters == rhs.fReplaceTabCharacters &&
+           this->fApplyRoundingHack == rhs.fApplyRoundingHack;
+}
+
+bool ParagraphStyle::equalsByLayout(const ParagraphStyle& rhs) const {
+    return this->fStrutStyle == rhs.fStrutStyle &&
+           this->fDefaultTextStyle.equalsByFonts(rhs.fDefaultTextStyle) &&
+           this->fTextAlign == rhs.fTextAlign &&
+           this->fTextDirection == rhs.fTextDirection &&
+           this->fLinesLimit == rhs.fLinesLimit &&
+           this->fEllipsisUtf16 == rhs.fEllipsisUtf16 &&
+           this->fEllipsis == rhs.fEllipsis &&
+           nearlyEqual(fHeight, rhs.fHeight) &&
+           this->fTextHeightBehavior == rhs.fTextHeightBehavior &&
+           this->fTextIndent == rhs.fTextIndent &&
+           this->fFontRastrSettings == rhs.fFontRastrSettings &&
+           this->fHintingIsOn == rhs.fHintingIsOn &&
+           this->fReplaceTabCharacters == rhs.fReplaceTabCharacters &&
+           this->fApplyRoundingHack == rhs.fApplyRoundingHack;
+}
+
 ParagraphStyle::ParagraphStyle() {
     fTextAlign = TextAlign::kStart;
     fTextDirection = TextDirection::kLtr;

--- a/modules/skparagraph/src/ParagraphStyle.cpp
+++ b/modules/skparagraph/src/ParagraphStyle.cpp
@@ -24,16 +24,13 @@ TextIndent::TextIndent() {
     fRestLine = 0.0;
 }
 
-
-bool ParagraphStyle::equals(const ParagraphStyle& rhs) const {
+bool ParagraphStyle::almostEquals(const ParagraphStyle& rhs) const {
     return this->fStrutStyle == rhs.fStrutStyle &&
-           this->fDefaultTextStyle == rhs.fDefaultTextStyle &&
            this->fTextAlign == rhs.fTextAlign &&
            this->fTextDirection == rhs.fTextDirection &&
            this->fLinesLimit == rhs.fLinesLimit &&
            this->fEllipsisUtf16 == rhs.fEllipsisUtf16 &&
            this->fEllipsis == rhs.fEllipsis &&
-           this->fHeight == rhs.fHeight &&
            this->fTextHeightBehavior == rhs.fTextHeightBehavior &&
            this->fTextIndent == rhs.fTextIndent &&
            this->fFontRastrSettings == rhs.fFontRastrSettings &&
@@ -42,21 +39,16 @@ bool ParagraphStyle::equals(const ParagraphStyle& rhs) const {
            this->fApplyRoundingHack == rhs.fApplyRoundingHack;
 }
 
+bool ParagraphStyle::equals(const ParagraphStyle& rhs) const {
+    return this->almostEquals(rhs) &&
+           this->fDefaultTextStyle == rhs.fDefaultTextStyle &&
+           this->fHeight == rhs.fHeight;
+}
+
 bool ParagraphStyle::equalsByLayout(const ParagraphStyle& rhs) const {
-    return this->fStrutStyle == rhs.fStrutStyle &&
+    return this->almostEquals(rhs) &&
            this->fDefaultTextStyle.equalsByFonts(rhs.fDefaultTextStyle) &&
-           this->fTextAlign == rhs.fTextAlign &&
-           this->fTextDirection == rhs.fTextDirection &&
-           this->fLinesLimit == rhs.fLinesLimit &&
-           this->fEllipsisUtf16 == rhs.fEllipsisUtf16 &&
-           this->fEllipsis == rhs.fEllipsis &&
-           nearlyEqual(fHeight, rhs.fHeight) &&
-           this->fTextHeightBehavior == rhs.fTextHeightBehavior &&
-           this->fTextIndent == rhs.fTextIndent &&
-           this->fFontRastrSettings == rhs.fFontRastrSettings &&
-           this->fHintingIsOn == rhs.fHintingIsOn &&
-           this->fReplaceTabCharacters == rhs.fReplaceTabCharacters &&
-           this->fApplyRoundingHack == rhs.fApplyRoundingHack;
+           nearlyEqual(fHeight, rhs.fHeight);
 }
 
 ParagraphStyle::ParagraphStyle() {

--- a/modules/skparagraph/tests/SkParagraphTest.cpp
+++ b/modules/skparagraph/tests/SkParagraphTest.cpp
@@ -5387,6 +5387,7 @@ UNIX_ONLY_TEST(SkParagraph_CacheStyles, reporter) {
     TextStyle text_style;
     text_style.setFontFamilies({SkString("Roboto")});
     text_style.setColor(SK_ColorBLACK);
+    paragraph_style.setTextStyle(text_style);
 
     const char* text = "text";
     const size_t len = strlen(text);
@@ -5407,6 +5408,9 @@ UNIX_ONLY_TEST(SkParagraph_CacheStyles, reporter) {
     };
 
     test(0, false);
+    // setting forground color should not affect cache match
+    text_style.setForegroundColor(SkPaint());
+    paragraph_style.setTextStyle(text_style);
     test(1, true);
     text_style.setLetterSpacing(10);
     test(1, false);


### PR DESCRIPTION
Relax style comparison for layout cache to fix finding valid cached values

Fixes https://youtrack.jetbrains.com/issue/CMP-6879