### PR TITLE
Add -sSUPPORT_LONGJMP=wasm

### DIFF
--- a/modules/canvaskit/BUILD.bazel
+++ b/modules/canvaskit/BUILD.bazel
@@ -30,6 +30,7 @@ BASE_LINKOPTS = [
     "-sDYNAMIC_EXECUTION=0",
     "-sFILESYSTEM=0",
     "-sEXPORTED_FUNCTIONS=['_malloc','_free']",
+    "-sSUPPORT_LONGJMP=wasm"
 ]
 
 RELEASE_OPTS = [

--- a/modules/canvaskit/BUILD.gn
+++ b/modules/canvaskit/BUILD.gn
@@ -328,6 +328,7 @@ skia_wasm_lib("canvaskit") {
     "-sINITIAL_MEMORY=128MB",
     "-sWASM",
     "-sSTRICT=1",
+    "-sSUPPORT_LONGJMP=wasm"
   ]
 
   defines = [

--- a/modules/canvaskit/compile.sh
+++ b/modules/canvaskit/compile.sh
@@ -261,6 +261,7 @@ echo "Compiling"
   skia_canvaskit_enable_debugger=${DEBUGGER_ENABLED} \
   skia_canvaskit_enable_paragraph=${ENABLE_PARAGRAPH} \
   skia_canvaskit_enable_webgl=${ENABLE_WEBGL} \
-  skia_canvaskit_enable_webgpu=${ENABLE_WEBGPU}"
+  skia_canvaskit_enable_webgpu=${ENABLE_WEBGPU} \
+  extra_cflags=[\"-sSUPPORT_LONGJMP=wasm\"]"
 
 ${NINJA} -C ${BUILD_DIR} canvaskit.js


### PR DESCRIPTION
https://emscripten.org/docs/porting/setjmp-longjmp.html#webassembly-exception-handling-based-setjmp-longjmp-support

> This option leverages a new feature that brings built-in instructions for throwing and catching exceptions to WebAssembly. As a result, it can reduce code size and performance overhead compared to the JavaScript-based implementation. 