### PR TITLE
fix: SkParse::FindScalar is locale-dependent

### DIFF
--- a/src/utils/SkParse.cpp
+++ b/src/utils/SkParse.cpp
@@ -174,12 +174,28 @@ const char* SkParse::FindS32(const char str[], int32_t* value)
     return str;
 }
 
+#include <locale.h>
+
+#if defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
+#include <xlocale.h>
+#endif
+
+#if defined(SK_BUILD_FOR_WIN)
+  static const _locale_t kDefaultLocale = _create_locale(LC_ALL, "C");
+#else
+  static const locale_t kDefaultLocale = newlocale(LC_ALL_MASK, "C", nullptr);
+#endif
+
 const char* SkParse::FindScalar(const char str[], SkScalar* value) {
     SkASSERT(str);
     str = skip_ws(str);
 
     char* stop;
-    float v = (float)strtod(str, &stop);
+    #if defined(SK_BUILD_FOR_WIN)
+        float v = _strtof_l(str, &stop, kDefaultLocale);
+    #else
+        float v = strtof_l(str, &stop, kDefaultLocale);
+    #endif
     if (str == stop) {
         return nullptr;
     }


### PR DESCRIPTION
Which causes SVG files with decimal values to not be properly parsed in e.g. Fleet on Linux when the locale is set to one that uses `,` as a decimal separator (e.g. `de_DE.UTF-8`).
Fix is based on the similar [fix SkSVGCanvas serialization is locale-dependent](https://github.com/jetbrains/skia/commit/785eca66d6691288d3032876804aaa36ec5dbe52).