### PR TITLE
[SkParagraph] Fix line height overriding corner cases

### DIFF
--- a/modules/skparagraph/include/TextStyle.h
+++ b/modules/skparagraph/include/TextStyle.h
@@ -259,7 +259,7 @@ public:
     void setBaselineShift(SkScalar baselineShift) { fBaselineShift = baselineShift; }
 
     void setHeight(SkScalar height) { fHeight = height; }
-    SkScalar getHeight() const { return fHeightOverride ? fHeight : 0; }
+    SkScalar getHeight() const { return fHeightOverride ? fHeight : 1.0f; }
 
     void setHeightOverride(bool heightOverride) { fHeightOverride = heightOverride; }
     bool getHeightOverride() const { return fHeightOverride; }

--- a/modules/skparagraph/src/OneLineShaper.cpp
+++ b/modules/skparagraph/src/OneLineShaper.cpp
@@ -638,7 +638,7 @@ bool OneLineShaper::shape() {
             auto blockSpan = SkSpan<Block>(&block, 1);
 
             // Start from the beginning (hoping that it's a simple case one block - one run)
-            fHeight = block.fStyle.getHeightOverride() ? block.fStyle.getHeight() : 0;
+            fHeight = block.fStyle.getHeight();
             fTopRatio = block.fStyle.getTopRatio();
             fBaselineShift = block.fStyle.getBaselineShift();
             fAdvance = SkVector::Make(advanceX, 0);

--- a/modules/skparagraph/src/Run.cpp
+++ b/modules/skparagraph/src/Run.cpp
@@ -62,9 +62,6 @@ void Run::calculateMetrics() {
     fCorrectAscent = fFontMetrics.fAscent - fFontMetrics.fLeading * 0.5;
     fCorrectDescent = fFontMetrics.fDescent + fFontMetrics.fLeading * 0.5;
     fCorrectLeading = 0;
-    if (SkScalarNearlyZero(fHeightMultiplier)) {
-        return;
-    }
     const auto runHeight = fHeightMultiplier * fFont.getSize();
     const auto fontIntrinsicHeight = fCorrectDescent - fCorrectAscent;
     if (fTopRatio >= 0.0f && fTopRatio <= 1.0f) {


### PR DESCRIPTION
[CMP-7963](https://youtrack.jetbrains.com/issue/CMP-7963) Setting 0.sp lineHeight to BasicText does not work
[CMP-5782](https://youtrack.jetbrains.com/issue/CMP-5782) `baselineShift` works only when `lineHeight` is specified


## Testing

I don't see existing infra in this repo to add such tests, so just checking on Compose level:

```kt
BasicText(
    "Hello\nThere",
    style = TextStyle(
        lineHeight = 0.sp
    )
)
```
<img width="137" height="78" alt="image" src="https://github.com/user-attachments/assets/52cb85cb-1df0-4e3c-93ee-9d774aa8eba4" />

