### PR TITLE
Use real drawable bounds instead of `worstCaseBounds` if available

### DIFF
--- a/src/core/SkPictureRecorder.cpp
+++ b/src/core/SkPictureRecorder.cpp
@@ -81,9 +81,16 @@ sk_sp<SkPicture> SkPictureRecorder::finishRecordingAsPicture() {
     };
 
     if (fBBH) {
+        SkPicture const* const* drawablePicts = nullptr;
+        int drawableCount = 0;
+        if (pictList) {
+            drawablePicts = pictList->begin();
+            drawableCount = pictList->count();
+        }
+
         AutoTArray<SkRect> bounds(fRecord->count());
         AutoTMalloc<SkBBoxHierarchy::Metadata> meta(fRecord->count());
-        SkRecordFillBounds(fCullRect, *fRecord, bounds.data(), meta);
+        SkRecordFillBounds(fCullRect, *fRecord, drawablePicts, drawableCount, bounds.data(), meta);
 
         fBBH->insert(bounds.data(), meta, fRecord->count());
 

--- a/src/core/SkRecordDraw.cpp
+++ b/src/core/SkRecordDraw.cpp
@@ -205,8 +205,11 @@ template <> void Draw::draw(const DrawDrawable& r) {
 class FillBounds : SkNoncopyable {
 public:
     FillBounds(const SkRect& cullRect, const SkRecord& record,
+               SkPicture const* const drawablePicts[], int drawableCount,
                SkRect bounds[], SkBBoxHierarchy::Metadata meta[])
         : fCullRect(cullRect)
+        , fDrawablePicts(drawablePicts)
+        , fDrawableCount(drawableCount)
         , fBounds(bounds)
         , fMeta(meta) {
         fCTM = SkMatrix::I();
@@ -503,6 +506,16 @@ private:
     }
 
     Bounds bounds(const DrawDrawable& op) const {
+        if (fDrawablePicts) {
+            SkASSERT(op.index >= 0);
+            SkASSERT(op.index < fDrawableCount);
+            SkPicture const *picture = fDrawablePicts[op.index];
+            SkRect dst = picture->cullRect();
+            if (op.matrix) {
+                op.matrix->mapRect(&dst);
+            }
+            return this->adjustAndMap(dst, nullptr);
+        }
         return this->adjustAndMap(op.worstCaseBounds, nullptr);
     }
 
@@ -564,6 +577,10 @@ private:
     // We do not guarantee anything for operations outside of the cull rect
     const SkRect fCullRect;
 
+    // Reference to captured pictures to get correct bounds. Same approach as in SkRecords::Draw.
+    SkPicture const* const* fDrawablePicts;
+    int fDrawableCount;
+
     // Conservative identity-space bounds for each op in the SkRecord.
     Bounds* fBounds;
 
@@ -584,11 +601,15 @@ private:
 
 void SkRecordFillBounds(const SkRect& cullRect, const SkRecord& record,
                         SkRect bounds[], SkBBoxHierarchy::Metadata meta[]) {
-    {
-        SkRecords::FillBounds visitor(cullRect, record, bounds, meta);
-        for (int i = 0; i < record.count(); i++) {
-            visitor.setCurrentOp(i);
-            record.visit(i, visitor);
-        }
+    SkRecordFillBounds(cullRect, record, nullptr, 0, bounds, meta);
+}
+
+void SkRecordFillBounds(const SkRect& cullRect, const SkRecord& record,
+                        SkPicture const* const drawablePicts[], int drawableCount,
+                        SkRect bounds[], SkBBoxHierarchy::Metadata meta[]) {
+    SkRecords::FillBounds visitor(cullRect, record, drawablePicts, drawableCount, bounds, meta);
+    for (int i = 0; i < record.count(); i++) {
+        visitor.setCurrentOp(i);
+        record.visit(i, visitor);
     }
 }

--- a/src/core/SkRecordDraw.h
+++ b/src/core/SkRecordDraw.h
@@ -19,7 +19,10 @@ class SkRecord;
 struct SkRect;
 
 // Calculate conservative identity space bounds for each op in the record.
-void SkRecordFillBounds(const SkRect& cullRect, const SkRecord&,
+void SkRecordFillBounds(const SkRect& cullRect, const SkRecord& record,
+                        SkRect bounds[], SkBBoxHierarchy::Metadata[]);
+void SkRecordFillBounds(const SkRect& cullRect, const SkRecord& record,
+                        SkPicture const* const drawablePicts[], int drawableCount,
                         SkRect bounds[], SkBBoxHierarchy::Metadata[]);
 
 // Draw an SkRecord into an SkCanvas.  A convenience wrapper around SkRecords::Draw.

--- a/tests/PictureBBHTest.cpp
+++ b/tests/PictureBBHTest.cpp
@@ -9,6 +9,7 @@
 #include "include/core/SkBitmap.h"
 #include "include/core/SkCanvas.h"
 #include "include/core/SkColor.h"
+#include "include/core/SkDrawable.h"
 #include "include/core/SkPaint.h"
 #include "include/core/SkPicture.h"
 #include "include/core/SkPictureRecorder.h"
@@ -124,4 +125,35 @@ DEF_TEST(PictureNegativeSpace, r) {
         REPORTER_ASSERT(r, pic->approximateOpCount() == 3);
         REPORTER_ASSERT(r, pic->cullRect() == (SkRect{-20,-20,-10,-10}));
     }
+}
+
+class CustomDrawable : public SkDrawable {
+public:
+    void onDraw(SkCanvas* canvas) override {
+        canvas->drawRect({ 20, 20, 40, 40 }, SkPaint {});
+    }
+
+    SkRect onGetBounds() override {
+        return SkRect { 0, 0, 100, 100 };
+    }
+
+protected:
+    sk_sp<SkPicture> onMakePictureSnapshot() override {
+        SkRTreeFactory bbhFactory;
+        SkPictureRecorder recorder;
+        SkCanvas* canvas = recorder.beginRecording(this->getBounds(), &bbhFactory);
+        this->draw(canvas);
+        return recorder.finishRecordingAsPicture();
+    }
+};
+
+DEF_TEST(PictureBBHFromDrawable, r) {
+    SkRTreeFactory bbhFactory;
+    SkPictureRecorder recorder;
+    auto drawable = sk_make_sp<CustomDrawable>();
+
+    auto canvas = recorder.beginRecording({ 0, 0, 100, 100 }, &bbhFactory);
+    canvas->drawDrawable(drawable.get());
+    auto pic = recorder.finishRecordingAsPicture();
+    REPORTER_ASSERT(r, pic->cullRect() == (SkRect { 20, 20, 40, 40 }));
 }


### PR DESCRIPTION
Fixes [CMP-8701](https://youtrack.jetbrains.com/issue/CMP-8701)

In case of captured `SkPicture` from `SkDrawable` during `finishRecordingAsPicture`, we can use real bounds instead of `worstCaseBounds`. It's important to measure real drawings bounds after migrating to skiko's `RenderNode` that uses `SkDrawable`s under the hood