### PR TITLE
Fix default leading in case if `fHeightOverride == false`

### DIFF
--- a/modules/skparagraph/include/TextStyle.h
+++ b/modules/skparagraph/include/TextStyle.h
@@ -259,7 +259,7 @@ public:
     void setBaselineShift(SkScalar baselineShift) { fBaselineShift = baselineShift; }
 
     void setHeight(SkScalar height) { fHeight = height; }
-    SkScalar getHeight() const { return fHeightOverride ? fHeight : 1.0f; }
+    SkScalar getHeight() const { return fHeightOverride ? fHeight : 0.0f; }
 
     void setHeightOverride(bool heightOverride) { fHeightOverride = heightOverride; }
     bool getHeightOverride() const { return fHeightOverride; }

--- a/modules/skparagraph/src/OneLineShaper.cpp
+++ b/modules/skparagraph/src/OneLineShaper.cpp
@@ -144,7 +144,7 @@ void OneLineShaper::fillGaps(size_t startingCount) {
     }
 }
 
-void OneLineShaper::finish(const Block& block, SkScalar height, SkScalar& advanceX) {
+void OneLineShaper::finish(const Block& block, SkScalar height, bool heightOverride, SkScalar& advanceX) {
     auto blockText = block.fRange;
 
     // Add all unresolved blocks to resolved blocks
@@ -210,6 +210,7 @@ void OneLineShaper::finish(const Block& block, SkScalar height, SkScalar& advanc
                     info,
                     run->fClusterStart,
                     height,
+                    heightOverride,
                     block.fStyle.getTopRatio(),
                     block.fStyle.getBaselineShift(),
                     this->fParagraph->fRuns.size(),
@@ -599,9 +600,10 @@ bool OneLineShaper::iterateThroughShapingRegions(const ShapeVisitor& shape) {
         auto& run = fParagraph->fRuns.emplace_back(this->fParagraph,
                                        runInfo,
                                        placeholder.fRange.start,
-                                       0.0f,
-                                       0.0f,
-                                       false,
+                                       0.0f, // heightMultiplier
+                                       false, // heightOverride
+                                       -1.0f, // topRatio
+                                       0.0f, // baselineShift
                                        fParagraph->fRuns.size(),
                                        advanceX);
 
@@ -639,6 +641,7 @@ bool OneLineShaper::shape() {
 
             // Start from the beginning (hoping that it's a simple case one block - one run)
             fHeight = block.fStyle.getHeight();
+            fHeightOverride = block.fStyle.getHeightOverride();
             fTopRatio = block.fStyle.getTopRatio();
             fBaselineShift = block.fStyle.getBaselineShift();
             fAdvance = SkVector::Make(advanceX, 0);
@@ -719,7 +722,7 @@ bool OneLineShaper::shape() {
                 }
             });
 
-            this->finish(block, fHeight, advanceX);
+            this->finish(block, fHeight, fHeightOverride, advanceX);
         });
 
         return true;

--- a/modules/skparagraph/src/OneLineShaper.h
+++ b/modules/skparagraph/src/OneLineShaper.h
@@ -18,6 +18,7 @@ public:
     explicit OneLineShaper(ParagraphImpl* paragraph)
         : fParagraph(paragraph)
         , fHeight(0.0f)
+        , fHeightOverride(false)
         , fTopRatio(-1.0f)
         , fBaselineShift(0.0f)
         , fAdvance(SkPoint::Make(0.0f, 0.0f))
@@ -81,7 +82,7 @@ private:
 #ifdef SK_DEBUG
     void printState();
 #endif
-    void finish(const Block& block, SkScalar height, SkScalar& advanceX);
+    void finish(const Block& block, SkScalar height, bool heightOverride, SkScalar& advanceX);
 
     void beginLine() override {}
     void runInfo(const RunInfo&) override {}
@@ -93,6 +94,7 @@ private:
                                            info,
                                            fCurrentText.start,
                                            fHeight,
+                                           fHeightOverride,
                                            fTopRatio,
                                            fBaselineShift,
                                            ++fUniqueRunId,
@@ -115,6 +117,7 @@ private:
     ParagraphImpl* fParagraph;
     TextRange fCurrentText;
     SkScalar fHeight;
+    bool fHeightOverride;
     SkScalar fTopRatio;
     SkScalar fBaselineShift;
     SkVector fAdvance;

--- a/modules/skparagraph/src/Run.cpp
+++ b/modules/skparagraph/src/Run.cpp
@@ -18,6 +18,7 @@ Run::Run(ParagraphImpl* owner,
          const SkShaper::RunHandler::RunInfo& info,
          size_t firstChar,
          SkScalar heightMultiplier,
+         bool heightOverride,
          SkScalar topRatio,
          SkScalar baselineShift,
          size_t index,
@@ -33,6 +34,7 @@ Run::Run(ParagraphImpl* owner,
     , fOffsets(fGlyphData->offsets)
     , fClusterIndexes(fGlyphData->clusterIndexes)
     , fHeightMultiplier(heightMultiplier)
+    , fHeightOverride(heightOverride)
     , fTopRatio(topRatio)
     , fBaselineShift(baselineShift)
 {
@@ -62,17 +64,21 @@ void Run::calculateMetrics() {
     fCorrectAscent = fFontMetrics.fAscent - fFontMetrics.fLeading * 0.5;
     fCorrectDescent = fFontMetrics.fDescent + fFontMetrics.fLeading * 0.5;
     fCorrectLeading = 0;
-    const auto runHeight = fHeightMultiplier * fFont.getSize();
-    const auto fontIntrinsicHeight = fCorrectDescent - fCorrectAscent;
-    if (fTopRatio >= 0.0f && fTopRatio <= 1.0f) {
-        const auto extraLeading = runHeight - fontIntrinsicHeight;
-        fCorrectAscent -= extraLeading * fTopRatio;
-        fCorrectDescent += extraLeading * (1.0f - fTopRatio);
-    } else {
-        const auto multiplier = runHeight / fontIntrinsicHeight;
-        fCorrectAscent *= multiplier;
-        fCorrectDescent *= multiplier;
+
+    if (fHeightOverride) {
+        const auto runHeight = fHeightMultiplier * fFont.getSize();
+        const auto fontIntrinsicHeight = fCorrectDescent - fCorrectAscent;
+        if (fTopRatio >= 0.0f && fTopRatio <= 1.0f) {
+            const auto extraLeading = runHeight - fontIntrinsicHeight;
+            fCorrectAscent -= extraLeading * fTopRatio;
+            fCorrectDescent += extraLeading * (1.0f - fTopRatio);
+        } else {
+            const auto multiplier = runHeight / fontIntrinsicHeight;
+            fCorrectAscent *= multiplier;
+            fCorrectDescent *= multiplier;
+        }
     }
+
     // If we shift the baseline we need to make sure the shifted text fits the line
     fCorrectAscent += fBaselineShift;
     fCorrectDescent += fBaselineShift;

--- a/modules/skparagraph/src/Run.h
+++ b/modules/skparagraph/src/Run.h
@@ -58,6 +58,7 @@ public:
         const SkShaper::RunHandler::RunInfo& info,
         size_t firstChar,
         SkScalar heightMultiplier,
+        bool heightOverride,
         SkScalar topRatio,
         SkScalar baselineShift,
         size_t index,
@@ -97,6 +98,7 @@ public:
     TextDirection getTextDirection() const { return leftToRight() ? TextDirection::kLtr : TextDirection::kRtl; }
     size_t index() const { return fIndex; }
     SkScalar heightMultiplier() const { return fHeightMultiplier; }
+    bool heightOverride() const { return fHeightOverride; }
     SkScalar topRatio() const { return fTopRatio; }
     SkScalar baselineShift() const { return fBaselineShift; }
     PlaceholderStyle* placeholderStyle() const;
@@ -204,6 +206,7 @@ private:
 
     SkFontMetrics fFontMetrics;
     const SkScalar fHeightMultiplier;
+    const bool fHeightOverride;
     const SkScalar fTopRatio;
     const SkScalar fBaselineShift;
     SkScalar fCorrectAscent;

--- a/modules/skparagraph/src/TextLine.cpp
+++ b/modules/skparagraph/src/TextLine.cpp
@@ -643,8 +643,17 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
 
     class ShapeHandler final : public SkShaper::RunHandler {
     public:
-        ShapeHandler(SkScalar lineHeight, SkScalar topRatio, SkScalar baselineShift, const SkString& ellipsis)
-            : fRun(nullptr), fLineHeight(lineHeight), fTopRatio(topRatio), fBaselineShift(baselineShift), fEllipsis(ellipsis) {}
+        ShapeHandler(SkScalar lineHeight,
+                bool lineHeightOverride,
+                SkScalar topRatio,
+                SkScalar baselineShift,
+                const SkString& ellipsis)
+            : fRun(nullptr)
+            , fLineHeight(lineHeight)
+            , fLineHeightOverride(lineHeightOverride)
+            , fTopRatio(topRatio)
+            , fBaselineShift(baselineShift)
+            , fEllipsis(ellipsis) {}
         std::unique_ptr<Run> run() & { return std::move(fRun); }
 
     private:
@@ -656,7 +665,7 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
 
         Buffer runBuffer(const RunInfo& info) override {
             SkASSERT(!fRun);
-            fRun = std::make_unique<Run>(nullptr, info, 0, fLineHeight, fTopRatio, fBaselineShift, 0, 0);
+            fRun = std::make_unique<Run>(nullptr, info, 0, fLineHeight, fLineHeightOverride, fTopRatio, fBaselineShift, 0, 0);
             return fRun->newRunBuffer();
         }
 
@@ -671,6 +680,7 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
 
         std::unique_ptr<Run> fRun;
         SkScalar fLineHeight;
+        bool fLineHeightOverride;
         SkScalar fTopRatio;
         SkScalar fBaselineShift;
         SkString fEllipsis;
@@ -690,7 +700,7 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
     }
 
     auto shaped = [&](sk_sp<SkTypeface> typeface, sk_sp<SkFontMgr> fallback) -> std::unique_ptr<Run> {
-        ShapeHandler handler(run.heightMultiplier(), run.topRatio(), run.baselineShift(), ellipsis);
+        ShapeHandler handler(run.heightMultiplier(), run.heightOverride(), run.topRatio(), run.baselineShift(), ellipsis);
         SkFont font(std::move(typeface), textStyle.getFontSize());
         font.setEdging(SkFont::Edging::kAntiAlias);
         font.setHinting(SkFontHinting::kSlight);


### PR DESCRIPTION
`org.jetbrains.skia.ParagraphTest` in skiko detected undisired behaviour change after #10. This change fixes it.

The problem here is #10 assumed that `TextStyle.height = null` and `TextStyle.height = 1.0` are the same, but it should behave differently.
`TextStyle.height = 1.0` makes text line height equal to `fontSize`
`TextStyle.height = null` should make text line height equal `fontSize + leading`