### PR TITLE
[SkParagraph] Fix `baselineShift` application and metrics calculation

### DIFF
--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -1039,19 +1039,19 @@ void ParagraphImpl::computeEmptyMetrics() {
         textStyle.getHeightOverride()) {
         const auto intrinsicHeight = fEmptyMetrics.height();
         const auto strutHeight = textStyle.getHeight() * textStyle.getFontSize();
-        SkScalar topRatio = paragraphStyle().getStrutStyle().getTopRatio();
+        SkScalar topRatio = textStyle.getTopRatio();
         if (topRatio >= 0.0f && topRatio <= 1.0f) {
             const auto extraLeading = strutHeight - intrinsicHeight;
             fEmptyMetrics.update(
                 fEmptyMetrics.ascent() - extraLeading * topRatio,
                 fEmptyMetrics.descent() + extraLeading * (1.0f - topRatio),
-                fEmptyMetrics.leading() + extraLeading);
+                fEmptyMetrics.leading());
         } else {
             const auto multiplier = strutHeight / intrinsicHeight;
             fEmptyMetrics.update(
                 fEmptyMetrics.ascent() * multiplier,
                 fEmptyMetrics.descent() * multiplier,
-                fEmptyMetrics.leading() * multiplier);
+                fEmptyMetrics.leading());
         }
     }
 

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -590,6 +590,10 @@ void ParagraphImpl::breakShapedTextIntoLines(SkScalar maxWidth) {
         auto textRange = TextRange(0, this->text().size());
         auto textExcludingSpaces = TextRange(0, fTrailingSpaces);
         InternalLineMetrics metrics(this->strutForceHeight());
+
+        // It's important to always take into account empty metrics because baseline shifting needs to keep
+        // the original placement inside final metrics.
+        metrics.add(this->getEmptyMetrics());
         metrics.add(&run);
         auto disableFirstAscent = this->paragraphStyle().getTextHeightBehavior() &
                                   TextHeightBehavior::kDisableFirstAscent;

--- a/modules/skparagraph/src/Run.h
+++ b/modules/skparagraph/src/Run.h
@@ -90,8 +90,8 @@ public:
     SkScalar ascent() const { return fFontMetrics.fAscent + fBaselineShift; }
     SkScalar descent() const { return fFontMetrics.fDescent + fBaselineShift; }
     SkScalar leading() const { return fFontMetrics.fLeading; }
-    SkScalar correctAscent() const { return fCorrectAscent + fBaselineShift; }
-    SkScalar correctDescent() const { return fCorrectDescent + fBaselineShift; }
+    SkScalar correctAscent() const { return fCorrectAscent; }
+    SkScalar correctDescent() const { return fCorrectDescent; }
     SkScalar correctLeading() const { return fCorrectLeading; }
     const SkFont& font() const { return fFont; }
     bool leftToRight() const { return fBidiLevel % 2 == 0; }

--- a/modules/skparagraph/src/TextStyle.cpp
+++ b/modules/skparagraph/src/TextStyle.cpp
@@ -171,15 +171,20 @@ void TextStyle::getFontMetrics(SkFontMetrics* metrics) const {
     font.setSubpixel(fFontRastrSettings.fSubpixel);
     font.setHinting(fFontRastrSettings.fHinting);
     font.getMetrics(metrics);
+    metrics->fAscent = metrics->fAscent - metrics->fLeading * 0.5f;
+    metrics->fDescent = metrics->fDescent + metrics->fLeading * 0.5f;
     if (fHeightOverride) {
-        auto multiplier = fHeight * fFontSize;
-        auto height = metrics->fDescent - metrics->fAscent + metrics->fLeading;
-        metrics->fAscent = (metrics->fAscent - metrics->fLeading / 2) * multiplier / height;
-        metrics->fDescent = (metrics->fDescent + metrics->fLeading / 2) * multiplier / height;
-
-    } else {
-        metrics->fAscent = (metrics->fAscent - metrics->fLeading / 2);
-        metrics->fDescent = (metrics->fDescent + metrics->fLeading / 2);
+        const auto overriddenHeight = fHeight * fFontSize;
+        const auto fontHeight = metrics->fDescent - metrics->fAscent;
+        if (fTopRatio >= 0.0f && fTopRatio <= 1.0f) {
+            const auto extraLeading = overriddenHeight - fontHeight;
+            metrics->fAscent -= extraLeading * fTopRatio;
+            metrics->fDescent += extraLeading * (1.0f - fTopRatio);
+        } else {
+            const auto multiplier = overriddenHeight / fontHeight;
+            metrics->fAscent *= multiplier;
+            metrics->fDescent *= multiplier;
+        }
     }
     // If we shift the baseline we need to make sure the shifted text fits the line
     metrics->fAscent += fBaselineShift;

--- a/modules/skparagraph/src/TextWrapper.cpp
+++ b/modules/skparagraph/src/TextWrapper.cpp
@@ -328,10 +328,9 @@ void TextWrapper::breakTextIntoLines(ParagraphImpl* parent,
             widthWithSpaces = fEndLine.widthWithGhostSpaces();
         }
 
-        // If the line is empty with the hard line break, let's take the paragraph font (flutter???)
-        if (fEndLine.metrics().isClean()) {
-            fEndLine.setMetrics(parent->getEmptyMetrics());
-        }
+        // It's important to always take into account empty metrics because baseline shifting needs to keep
+        // the original placement inside final metrics.
+        fEndLine.metrics().add(parent->getEmptyMetrics());
 
         // Deal with placeholder clusters == runs[@size==1]
         Run* lastRun = nullptr;


### PR DESCRIPTION
`TextStyleTest.canApplyBaselineShift` in skiko detected one more problem after #10 - double application of `baselineShift`.
This problem was actually existed before #10 but manifested itself only in case of overriden height inside `ParagraphBuilder` with multiple regions, so nobody spotted it before.
After #10, such problem started to happen even without overriden height because we removed additional condition due to [CMP-5782](https://youtrack.jetbrains.com/issue/CMP-5782).
This PR fixes the root cause of this problem - removes application of `fBaselineShift` second time in getters. It's not required because it was already added to `fCorrectAscent`/`fCorrectDescent` inside `calculateMetrics` method.

Also, it always take into account empty metrics because baseline shifting needs to keep the original placement inside final metrics. And fixes issues in empty metrics calculation to make resulted calculation correct