### PR TITLE
Run all skia tests on CI

### DIFF
--- a/.github/scripts/run_dm_tests_using_bot_config.py
+++ b/.github/scripts/run_dm_tests_using_bot_config.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+
+
+def parse_json_string_list(raw: str, flag_name: str) -> list[str]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON passed to {flag_name}: {exc}") from exc
+
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise SystemExit(f"Expected {flag_name} to decode to a list of strings")
+    return value
+
+
+def dm_wrapper() -> list[str]:
+    if sys.platform.startswith("linux"):
+        return ["xvfb-run", "--auto-servernum"]
+    if sys.platform == "darwin":
+        return []
+    raise SystemExit(f"Unsupported platform for DM test runner: {sys.platform}")
+
+
+def build_command(configs: list[str], matches: list[str]) -> list[str]:
+    wrapper = dm_wrapper()
+
+    cmd = [*wrapper, "out/Debug/dm", "-v"]
+    if configs:
+        cmd.extend(["--config", *configs])
+    cmd.extend(["--src", "tests"])
+    if matches:
+        cmd.extend(["--match", *matches])
+    return cmd
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run DM unit tests using configs and matches passed from GitHub Actions.",
+    )
+    parser.add_argument(
+        "--configs-json",
+        required=True,
+        help="JSON array of DM configs.",
+    )
+    parser.add_argument(
+        "--matches-json",
+        required=True,
+        help="JSON array of DM --match patterns.",
+    )
+    parser.add_argument(
+        "--print-command",
+        action="store_true",
+        help="Print the resolved DM command and exit.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    configs = parse_json_string_list(args.configs_json, "--configs-json")
+    matches = parse_json_string_list(args.matches_json, "--matches-json")
+    cmd = build_command(configs, matches)
+
+    if args.print_command:
+        print(shlex.join(cmd))
+        return 0
+
+    print("Using DM test args from GitHub Actions", file=sys.stderr)
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/tests_for_skiko.yml
+++ b/.github/workflows/tests_for_skiko.yml
@@ -8,19 +8,64 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: macos-13
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            configs:
+              - gl
+              - gldft
+              - glmsaa4
+              - gldmsaa
+            matches:
+              # From infra/bots/gen_tasks_logic/dm_flags.go
+              - "~^SkRuntimeBlender_Ganesh$" # skbug.com/458193911
+              - "~^BigImageTest_Ganesh$"
+          - os: macos-15
+            configs:
+              - mtl
+            matches:
+              # From infra/bots/gen_tasks_logic/dm_flags.go
+              - "~^BigImageTest_Ganesh$"
+              - "~^GrMeshTest$" # skbug.com/40038854
+              - "~^DMSAA_aa_dst_read_after_dmsaa$" # b/438450848
+              - "~^DMSAA_dst_read$" # b/438450848
+              - "~^SurfacePartialDraw_Gpu$" # b/438450848
+              - "~^FilterResult_ganesh_RescaleWithColorFilter$" # b/438450848
+              - "~^FilterResult_ganesh_RescaleWithTransform$" # b/438450848
+              - "~^FilterResult_ganesh_RescaleWithTileMode$" # b/438450848
+              - "~^FilterResult_ganesh_ColorFilterBetweenCrops$" # b/438450848
+              - "~^FilterResult_ganesh_TransformAndTile$" # b/438450848
+              - "~^FilterResult_ganesh_PeriodicTileCrops$" # b/438450848
+              - "~^FilterResult_ganesh_IntersectingCrops$" # b/438450848
+              - "~^FilterResult_ganesh_CropDisjointFromSourceAndOutput$" # b/438450848
+              - "~^FilterResult_ganesh_Crop$" # b/438450848
+              # Extra GitHub Actions workarounds
+              - "~^ProcessorCloneTest$" # flaky
+              - "~^FilterResult_ganesh_CroppedTransformedTransparencyAffectingColorFilter$"
+              - "~^FilterResult_ganesh_CroppedTransformedColorFilter$"
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.9'
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          ./tools/install_dependencies.sh --yes
 
       - name: Run git-sync-deps (skia)
-        run: python3 tools/git-sync-deps
+        run: |
+          python3 tools/git-sync-deps
 
       - name: Install Ninja
         run: |
@@ -33,12 +78,6 @@ jobs:
 
       - name: Run tests
         run: |
-          set +e
-          ./run_tests_for_skiko.sh
-          EXIT_CODE=$?
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "❌ Tests failed with exit code $EXIT_CODE"
-            exit $EXIT_CODE
-          else
-            echo "✅ Tests passed successfully"
-          fi
+          python3 .github/scripts/run_dm_tests_using_bot_config.py \
+            --configs-json '${{ toJSON(matrix.configs) }}' \
+            --matches-json '${{ toJSON(matrix.matches) }}'

--- a/run_tests_for_skiko.sh
+++ b/run_tests_for_skiko.sh
@@ -1,5 +1,0 @@
-# running locally? do not forget to install ninja - python3 bin/fetch-ninja
-
-bin/gn gen out/Debug
-./third_party/ninja/ninja -C out/Debug dm
-out/Debug/dm -v --match Skiko

--- a/skiko_tests/HOW_TO_SKIKO_TESTS.MD
+++ b/skiko_tests/HOW_TO_SKIKO_TESTS.MD
@@ -5,7 +5,8 @@ To read about Skia tests go to [testing.md](../site/docs/dev/testing/testing.md)
 1) Make sure to sync the dependencies: `python3 tools/git-sync-deps`
 2) Install ninja: `python3 bin/fetch-ninja`
 3) Build DM tool: `bin/gn gen out/Debug && ./third_party/ninja/ninja -C out/Debug dm`
-4) Run the relevant tests: `./run_tests_for_skiko.sh` (it runs all the tests defined with `DEF_TEST_SKIKO`)
+4) Run the Skiko-specific tests: `out/Debug/dm --src tests --match ^Skiko_`
+5) Run all unit tests as well: `out/Debug/dm --src tests`
 
 ### How to add a new test
 1) You can add a new test in any existing `.cpp` file in `skiko_tests` folder, or you can create a new `.cpp` file. Have a look at other files, for example [SkikoTestExample.cpp](./SkikoTestExample.cpp)
@@ -15,6 +16,3 @@ To read about Skia tests go to [testing.md](../site/docs/dev/testing/testing.md)
 **Note:** 
 It's possible to add new tests in other directories too (for example in `tests` with all other Skia tests). But it's important to use `DEF_TEST_SKIKO` to define the scope of the tests.
 Keeping the tests in `skiko-tests` directory is probably preferred for our needs, because it simplifies the maintenance.
-
-### GitHub action
-We have a workflow running on every PR to `skiko` branch. It runs `skiko_tests`. It can be found [here](../.github/workflows/tests_for_skiko.yml)


### PR DESCRIPTION
[SKIKO-1127](https://youtrack.jetbrains.com/issue/SKIKO-1127) Run all skia tests on CI

- Fixes "The configuration 'macos-13' is not supported"
- Runs all existing tests on Linux and macOS with ignore rules extracted from `infra/bots/gen_tasks_logic/dm_flags.go`