### PR TITLE
Move build scripts from skia-pack to skia repo

### DIFF
--- a/.github/workflows/build_for_skiko.yml
+++ b/.github/workflows/build_for_skiko.yml
@@ -1,0 +1,235 @@
+name: Build Skia Prebuilts For Skiko
+
+on:
+  push:
+    branches:
+      - skiko
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      skip_release:
+        description: 'Skip release related steps? (true/false)'
+        required: true
+        default: 'false'
+
+permissions:
+  contents: write
+
+env:
+  milestone: 144
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: version
+        shell: bash
+        run: |
+          SHA="$(git rev-parse --short=10 "$GITHUB_SHA")"
+          echo "value=m${{ env.milestone }}-${SHA}" >> "$GITHUB_OUTPUT"
+
+  macos:
+    needs: prepare
+    runs-on: ${{ fromJson('{"macos":"macos-15","ios":"macos-15","iosSim":"macos-15","tvos":"macos-15","tvosSim":"macos-15"}')[matrix.target] }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ["macos", "ios", "iosSim", "tvos", "tvosSim"]
+        machine: ["x64", "arm64"]
+        build_type: [Release, Debug]
+        exclude:
+          - target: tvos
+            machine: x64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: python3 tools/skia_release/check_release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target ${{ matrix.target }} --build-type ${{ matrix.build_type }} --machine ${{ matrix.machine }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Print Xcode version
+        run: xcodebuild -version
+      - run: python3 tools/skia_release/build.py --skia-dir . --build-type ${{ matrix.build_type }} --target ${{ matrix.target }} --machine ${{ matrix.machine }}
+      - run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target ${{ matrix.target }} --machine ${{ matrix.machine }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        with:
+          name: Skia-${{ needs.prepare.outputs.version }}-${{ matrix.target }}-${{ matrix.build_type }}-${{ matrix.machine }}.zip
+          path: '*.zip'
+      - run: python3 tools/skia_release/release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target ${{ matrix.target }} --machine ${{ matrix.machine }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  linux:
+    needs: prepare
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: ./tools/skia_release/prepare_linux.sh
+      - run: python3 tools/skia_release/check_release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 tools/skia_release/build.py --skia-dir . --build-type ${{ matrix.build_type }}
+      - run: PATH=/usr/lib/binutils-2.26/bin:$PATH python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        with:
+          name: Skia-${{ needs.prepare.outputs.version }}-linux-${{ matrix.build_type }}-x64.zip
+          path: '*.zip'
+      - run: python3 tools/skia_release/release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  linux-wasm:
+    needs: prepare
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: ./tools/skia_release/prepare_linux_wasm.sh
+      - run: python3 tools/skia_release/check_release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target wasm --build-type ${{ matrix.build_type }} --machine wasm
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: python3 tools/skia_release/build.py --skia-dir . --target wasm --machine wasm --build-type ${{ matrix.build_type }}
+      - run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target wasm --machine wasm --build-type ${{ matrix.build_type }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        with:
+          name: Skia-${{ needs.prepare.outputs.version }}-wasm-${{ matrix.build_type }}-wasm.zip
+          path: '*.zip'
+      - run: python3 tools/skia_release/release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target wasm --machine wasm --build-type ${{ matrix.build_type }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  linux-android:
+    needs: prepare
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+        machine: ["x64", "arm64"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: ./tools/skia_release/prepare_linux.sh
+      - run: python3 tools/skia_release/check_release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target android --build-type ${{ matrix.build_type }} --machine ${{ matrix.machine }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r25c
+      - run: python3 tools/skia_release/build.py --skia-dir . --target android --build-type ${{ matrix.build_type }} --machine ${{ matrix.machine }} --ndk ${{ steps.setup-ndk.outputs.ndk-path }}
+      - run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target android --build-type ${{ matrix.build_type }} --machine ${{ matrix.machine }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        with:
+          name: Skia-${{ needs.prepare.outputs.version }}-android-${{ matrix.build_type }}-${{ matrix.machine }}.zip
+          path: '*.zip'
+      - run: python3 tools/skia_release/release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target android --build-type ${{ matrix.build_type }} --machine ${{ matrix.machine }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  linux-arm64:
+    needs: prepare
+    runs-on: ubuntu-22.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: python3 tools/skia_release/check_release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target linux --machine arm64
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: addnab/docker-run-action@v3
+        name: Assemble
+        with:
+          image: arm64v8/ubuntu:20.04
+          options: -v ${{ github.workspace }}:/workspace -e BUILD_TYPE=${{ matrix.build_type }} -e BUILD_VERSION=${{ needs.prepare.outputs.version }} -e SKIA_BUILD_DIR=/workspace
+          shell: /bin/bash
+          run: |
+            set -euo pipefail
+            cd /workspace
+            /bin/bash tools/skia_release/prepare_linux_arm.sh
+            python3 tools/skia_release/build.py --skia-dir "${SKIA_BUILD_DIR}" --build-type "${BUILD_TYPE}" --target linux --machine arm64
+            python3 tools/skia_release/archive.py --skia-dir "${SKIA_BUILD_DIR}" --version "${BUILD_VERSION}" --build-type "${BUILD_TYPE}" --target linux --machine arm64
+      - uses: actions/upload-artifact@v4
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        with:
+          name: Skia-${{ needs.prepare.outputs.version }}-linux-${{ matrix.build_type }}-arm64.zip
+          path: '*.zip'
+      - run: python3 tools/skia_release/release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target linux --machine arm64
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  windows:
+    needs: prepare
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+        machine: ["x64", "arm64"]
+    steps:
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - shell: bash
+        run: python3 tools/skia_release/check_release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: microsoft/setup-msbuild@v1
+      - uses: ilammy/msvc-dev-cmd@v1
+      - shell: bash
+        run: python3 tools/skia_release/build.py --skia-dir . --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+      - shell: bash
+        run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        with:
+          name: Skia-${{ needs.prepare.outputs.version }}-windows-${{ matrix.build_type }}-${{ matrix.machine }}.zip
+          path: '*.zip'
+      - shell: bash
+        run: python3 tools/skia_release/release.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/skiko' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/skia_release/archive.py
+++ b/tools/skia_release/archive.py
@@ -1,0 +1,104 @@
+#! /usr/bin/env python3
+
+import pathlib
+import sys
+import zipfile
+
+import common
+
+
+def parents(path):
+  res = []
+  parent = path.parent
+  while str(parent) != '.':
+    res.insert(0, parent)
+    parent = parent.parent
+  return res
+
+
+def main():
+  skia_dir = common.skia_dir()
+
+  build_type = common.build_type()
+  version = common.version()
+  machine = common.machine()
+  target = common.target()
+  classifier = common.classifier()
+  out_bin = 'out/' + build_type + '-' + target + '-' + machine
+
+  globs = [
+      out_bin + '/*.a',
+      out_bin + '/*.lib',
+      out_bin + '/icudtl.dat',
+      'include/**/*',
+      'modules/particles/include/*.h',
+      'modules/skottie/include/*.h',
+      'modules/skottie/src/*.h',
+      'modules/skottie/src/animator/*.h',
+      'modules/skottie/src/effects/*.h',
+      'modules/skottie/src/layers/*.h',
+      'modules/skottie/src/layers/shapelayer/*.h',
+      'modules/skottie/src/text/*.h',
+      'modules/skparagraph/include/*.h',
+      'modules/skplaintexteditor/include/*.h',
+      'modules/skresources/include/*.h',
+      'modules/sksg/include/*.h',
+      'modules/skshaper/include/*.h',
+      'modules/skshaper/src/*.h',
+      'modules/svg/include/*.h',
+      'modules/skcms/src/*.h',
+      'modules/skcms/*.h',
+      'modules/skunicode/include/*.h',
+      'modules/skunicode/src/*.h',
+      'modules/jsonreader/*.h',
+      'src/base/*.h',
+      'src/core/*.h',
+      'src/gpu/ganesh/gl/*.h',
+      'src/utils/*.h',
+      'third_party/externals/angle2/LICENSE',
+      'third_party/externals/angle2/include/**/*',
+      'third_party/externals/freetype/docs/FTL.TXT',
+      'third_party/externals/freetype/docs/GPLv2.TXT',
+      'third_party/externals/freetype/docs/LICENSE.TXT',
+      'third_party/externals/freetype/include/**/*',
+      'third_party/externals/icu/source/common/**/*.h',
+      'third_party/externals/libpng/LICENSE',
+      'third_party/externals/libpng/*.h',
+      'third_party/externals/libwebp/COPYING',
+      'third_party/externals/libwebp/PATENTS',
+      'third_party/externals/libwebp/src/dec/*.h',
+      'third_party/externals/libwebp/src/dsp/*.h',
+      'third_party/externals/libwebp/src/enc/*.h',
+      'third_party/externals/libwebp/src/mux/*.h',
+      'third_party/externals/libwebp/src/utils/*.h',
+      'third_party/externals/libwebp/src/webp/*.h',
+      'third_party/externals/harfbuzz/COPYING',
+      'third_party/externals/harfbuzz/src/*.h',
+      'third_party/externals/swiftshader/LICENSE.txt',
+      'third_party/externals/swiftshader/include/**/*',
+      'third_party/externals/zlib/LICENSE',
+      'third_party/externals/zlib/*.h',
+      'third_party/icu/*.h',
+  ]
+
+  dist = 'Skia-' + version + '-' + target + '-' + build_type + '-' + machine + classifier + '.zip'
+  print('> Writing', dist)
+
+  with zipfile.ZipFile(skia_dir / dist, 'w', compression=zipfile.ZIP_DEFLATED) as zip_file:
+    dirs = set()
+    for glob in globs:
+      for path in pathlib.Path(skia_dir).glob(glob):
+        if path.is_dir():
+          continue
+        relative_path = path.relative_to(skia_dir)
+        for directory in parents(relative_path):
+          if directory not in dirs:
+            zip_file.write(skia_dir / directory, arcname=str(directory))
+            dirs.add(directory)
+        zip_file.write(path, arcname=str(relative_path))
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/skia_release/build.py
+++ b/tools/skia_release/build.py
@@ -1,0 +1,209 @@
+#! /usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+import common
+
+
+def git_sync_with_retries(skia_dir, max_retries=3, backoff_seconds=5):
+  attempt = 0
+  while True:
+    try:
+      print("> Running tools/git-sync-deps (attempt {}/{})".format(attempt + 1, max_retries + 1))
+      if common.host() == 'windows':
+        env = os.environ.copy()
+        env['PYTHONHTTPSVERIFY'] = '0'
+        subprocess.check_call([sys.executable, "tools/git-sync-deps"], cwd=skia_dir, env=env)
+      else:
+        subprocess.check_call([sys.executable, "tools/git-sync-deps"], cwd=skia_dir)
+      print("Success")
+      return
+    except subprocess.CalledProcessError as error:
+      attempt += 1
+      if attempt > max_retries:
+        print("All {} retries failed. Giving up.".format(max_retries))
+        raise
+      wait = backoff_seconds * attempt
+      print(f"Failed (exit {error.returncode}), retrying in {wait}s...")
+      time.sleep(wait)
+
+
+def patch_windows_toolchain(skia_dir):
+  toolchain_path = skia_dir / "gn" / "toolchain" / "BUILD.gn"
+  with toolchain_path.open("r", encoding="utf-8") as toolchain_file:
+    contents = toolchain_file.read()
+
+  patched = contents.replace(
+      'shell = "cmd.exe /c',
+      'shell = "cmd.exe /v:on /c',
+  ).replace(
+      r'env_setup = "$shell set \"PATH=%PATH%',
+      r'env_setup = "$shell set \"PATH=!PATH!',
+  )
+
+  if patched != contents:
+    with toolchain_path.open("w", encoding="utf-8") as toolchain_file:
+      toolchain_file.write(patched)
+
+
+def prepare_skia_checkout(skia_dir):
+  print("> Running tools/git-sync-deps")
+  git_sync_with_retries(skia_dir)
+
+  print("> Fetching ninja")
+  subprocess.check_call([sys.executable, "bin/fetch-ninja"], cwd=skia_dir)
+
+  if common.host() == 'windows':
+    patch_windows_toolchain(skia_dir)
+
+
+def ninja_path(host):
+  return os.path.join('third_party', 'ninja', 'ninja.exe' if host == 'windows' else 'ninja')
+
+
+def main():
+  skia_dir = common.skia_dir()
+  os.chdir(skia_dir)
+  prepare_skia_checkout(skia_dir)
+
+  build_type = common.build_type()
+  machine = common.machine()
+  host = common.host()
+  target = common.target()
+  ndk = common.ndk()
+
+  ninja = ninja_path(host)
+  is_ios = target in ('ios', 'iosSim')
+  is_tvos = target in ('tvos', 'tvosSim')
+  is_ios_sim = target == 'iosSim'
+  is_tvos_sim = target == 'tvosSim'
+  is_macos = target == 'macos'
+
+  if build_type == 'Debug':
+    args = ['is_debug=true']
+  else:
+    args = ['is_official_build=true']
+
+  args += [
+      'target_cpu="' + machine + '"',
+      'skia_use_system_expat=false',
+      'skia_use_system_libjpeg_turbo=false',
+      'skia_use_system_libpng=false',
+      'skia_use_system_libwebp=false',
+      'skia_use_system_zlib=false',
+      'skia_use_sfntly=false',
+      'skia_use_system_freetype2=false',
+      'skia_use_system_harfbuzz=false',
+      'skia_pdf_subset_harfbuzz=true',
+      'skia_use_system_icu=false',
+      'skia_enable_skottie=true',
+      'extra_cflags=[]',
+      'extra_cflags_cc=[]',
+  ]
+
+  if is_macos or is_ios or is_tvos:
+    if is_macos:
+      args += ['skia_use_fonthost_mac=true']
+    args += ['extra_cflags_cc+=["-frtti"]']
+    args += ['skia_use_metal=true']
+    if is_ios:
+      args += ['target_os="ios"']
+      if is_ios_sim:
+        args += ['ios_use_simulator=true']
+        args += ['extra_cflags+=["-mios-simulator-version-min=12.0"]']
+      else:
+        args += ['ios_min_target="12.0"']
+    elif is_tvos:
+      args += ['target_os="tvos"']
+      if is_tvos_sim:
+        args += ['ios_use_simulator=true']
+        args += ['extra_cflags+=["-mtvos-simulator-version-min=14", "-DSK_BUILD_FOR_TVOS"]']
+      else:
+        args += ['extra_cflags+=["-mtvos-version-min=14", "-DSK_BUILD_FOR_TVOS"]']
+    elif machine == 'arm64':
+      args += ['extra_cflags+=["-stdlib=libc++"]']
+    else:
+      args += ['extra_cflags+=["-stdlib=libc++", "-mmacosx-version-min=10.13"]']
+  elif target == 'linux':
+    if machine == 'arm64':
+      args += [
+          'skia_gl_standard="gles"',
+          'skia_use_egl=true',
+          'extra_cflags_cc+=["-fno-exceptions", "-fno-rtti", "-D_GLIBCXX_USE_CXX11_ABI=0", "-mno-outline-atomics"]',
+          'cc="gcc-10"',
+          'cxx="g++-10"',
+      ]
+    else:
+      args += [
+          'extra_cflags_cc+=["-fno-exceptions", "-fno-rtti","-D_GLIBCXX_USE_CXX11_ABI=0"]',
+          'cc="gcc-10"',
+          'cxx="g++-10"',
+      ]
+  elif target == 'windows':
+    args += [
+        'skia_use_direct3d=true',
+        'extra_cflags+=["-DSK_FONT_HOST_USE_SYSTEM_SETTINGS"]',
+    ]
+    if host == 'windows':
+      clang_path = shutil.which('clang-cl.exe')
+      if not clang_path:
+        raise Exception(
+          "Please install LLVM from https://releases.llvm.org/, "
+            "and make sure that clang-cl.exe is available in PATH"
+        )
+      args += [
+          'clang_win="' + os.path.dirname(os.path.dirname(clang_path)) + '"',
+          'is_trivial_abi=false',
+      ]
+  elif target == 'android':
+    args += ['ndk="' + ndk + '"']
+  elif target == 'wasm':
+    args += [
+        'skia_use_dng_sdk=false',
+        'skia_use_libjpeg_turbo_decode=true',
+        'skia_use_libjpeg_turbo_encode=true',
+        'skia_use_libpng_decode=true',
+        'skia_use_libpng_encode=true',
+        'skia_use_libwebp_decode=true',
+        'skia_use_libwebp_encode=true',
+        'skia_use_wuffs=true',
+        'skia_use_lua=false',
+        'skia_use_webgl=true',
+        'skia_use_piex=false',
+        'skia_use_system_libpng=false',
+        'skia_use_system_freetype2=false',
+        'skia_use_system_libjpeg_turbo=false',
+        'skia_use_system_libwebp=false',
+        'skia_enable_tools=false',
+        'skia_enable_fontmgr_custom_directory=false',
+        'skia_enable_fontmgr_custom_embedded=true',
+        'skia_enable_fontmgr_custom_empty=true',
+        'skia_use_webgl=true',
+        'skia_gl_standard="webgl"',
+        'skia_use_gl=true',
+        'skia_enable_gpu=true',
+        'skia_enable_svg=true',
+        'skia_use_expat=true',
+        'extra_cflags+=["-DSK_SUPPORT_GPU=1", "-DSK_GL", "-DSK_DISABLE_LEGACY_SHADERCONTEXT", "-sSUPPORT_LONGJMP=wasm"]',
+    ]
+
+  args += [
+      'extra_cflags+=["-USK_HIDE_PATH_EDIT_METHODS"]',
+      'extra_cflags_cc+=["-USK_HIDE_PATH_EDIT_METHODS"]',
+  ]
+
+  out = os.path.join('out', build_type + '-' + target + '-' + machine)
+  gn = 'gn.exe' if host == 'windows' else 'gn'
+  gn_cmd = [os.path.join('bin', gn), 'gen', out, '--args=' + ' '.join(args)]
+  print(gn_cmd)
+  subprocess.check_call(gn_cmd)
+  subprocess.check_call([ninja, '-C', out, 'skia', 'modules'])
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/skia_release/check_release.py
+++ b/tools/skia_release/check_release.py
@@ -1,0 +1,37 @@
+#! /usr/bin/env python3
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+import common
+
+
+def main():
+  headers = common.github_headers()
+  version = common.version()
+  build_type = common.build_type()
+  target = common.target()
+  machine = common.machine()
+  classifier = common.classifier()
+
+  try:
+    resp = urllib.request.urlopen(
+        urllib.request.Request(
+            'https://api.github.com/repos/' + common.github_repo() + '/releases/tags/' + version,
+            headers=headers,
+        )
+    ).read()
+    artifacts = [x['name'] for x in json.loads(resp.decode('utf-8'))['assets']]
+    zip_name = 'Skia-' + version + '-' + target + '-' + build_type + '-' + machine + classifier + '.zip'
+    if zip_name in artifacts:
+      print('> Artifact "' + zip_name + '" exists, stopping')
+      return 1
+    return 0
+  except urllib.error.URLError:
+    return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/skia_release/common.py
+++ b/tools/skia_release/common.py
@@ -1,0 +1,227 @@
+#! /usr/bin/env python3
+
+import argparse
+import base64
+import os
+import platform
+import re
+import subprocess
+from pathlib import Path
+
+
+def create_parser(version_required=False):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--build-type', default='Release')
+  parser.add_argument('--version', required=version_required)
+  parser.add_argument('--classifier')
+  parser.add_argument('--host')
+  parser.add_argument('--machine')
+  parser.add_argument('--ndk')
+  parser.add_argument('--skia-dir')
+  parser.add_argument('--target')
+  return parser
+
+
+def repo_root():
+  return Path(__file__).resolve().parents[2]
+
+
+def skia_dir():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  if args.skia_dir:
+    path = Path(args.skia_dir)
+    if not path.is_absolute():
+      path = repo_root() / path
+    return path.resolve()
+  return (repo_root() / 'build/skia').resolve()
+
+
+def host():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.host if args.host else {
+      'Darwin': 'macos',
+      'Linux': 'linux',
+      'Windows': 'windows',
+  }[platform.system()]
+
+
+def machine():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.machine if args.machine else {
+      'AMD64': 'x64',
+      'x86_64': 'x64',
+      'arm64': 'arm64',
+      'aarch64': 'arm64',
+  }[platform.machine()]
+
+
+def target():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.target if args.target else host()
+
+
+def version():
+  parser = create_parser()
+  args = parser.parse_args()
+
+  if args.version:
+    return args.version
+
+  branches = subprocess.check_output(
+      ['git', 'branch', '-a', '--contains', 'HEAD'],
+      cwd=skia_dir(),
+      text=True,
+  )
+  all_branches = subprocess.check_output(
+      ['git', 'branch', '-a'],
+      cwd=skia_dir(),
+      text=True,
+  )
+  milestone = infer_milestone(branches, all_branches)
+
+  if milestone is None:
+    raise RuntimeError(
+        'Unable to infer Skia milestone from branches containing HEAD. '
+        'Pass --version explicitly.'
+    )
+
+  revision = subprocess.check_output(
+      ['git', 'rev-parse', 'HEAD'],
+      cwd=skia_dir(),
+      text=True,
+  ).strip()
+  return milestone + '-' + revision[:10]
+
+
+def infer_milestone(branches, all_branches=''):
+  milestone = _find_milestone(branches, containing_head=True)
+  if milestone is not None:
+    return milestone
+  return _find_milestone(all_branches, containing_head=False)
+
+
+def _find_milestone(branches, containing_head):
+  milestone = None
+  patterns = [
+      r'(?m)^\s*(?:\* )?(?:remotes/[^/]+/)?chrome/(m\d+)$',
+      r'(?m)^\s*(?:\* )?(?:remotes/[^/]+/)?skiko-(m\d+)$',
+  ]
+
+  for pattern in patterns:
+    for match in re.finditer(pattern, branches):
+      milestone = match.group(1)
+      if containing_head:
+        return milestone
+
+  return milestone
+
+
+def build_type():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.build_type
+
+
+def classifier():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return '-' + args.classifier if args.classifier else ''
+
+
+def github_headers():
+  basic = os.environ.get('GITHUB_BASIC')
+  token = os.environ.get('GITHUB_TOKEN')
+  if basic:
+    auth = 'Basic ' + base64.b64encode(basic.encode('utf-8')).decode('utf-8')
+  elif token:
+    auth = 'Bearer ' + token
+  else:
+    raise RuntimeError('Either GITHUB_BASIC or GITHUB_TOKEN must be set')
+
+  return {
+      'Accept': 'application/vnd.github.v3+json',
+      'Authorization': auth,
+  }
+
+
+def github_repo():
+  repo = os.environ.get('GITHUB_REPOSITORY')
+  if repo:
+    return repo
+
+  cwd = repo_root()
+  remote_name = _current_branch_remote(cwd)
+  if remote_name is not None:
+    repo = _github_repo_from_remote_name(remote_name, cwd)
+    if repo is not None:
+      return repo
+
+  repos = _github_repos_from_remotes(cwd)
+  if len(repos) == 1:
+    return repos[0]
+  if len(repos) > 1:
+    raise RuntimeError(
+        'Unable to infer GitHub repo: multiple GitHub remotes found '
+        + f'({", ".join(repos)}). Set GITHUB_REPOSITORY explicitly.'
+    )
+  raise RuntimeError('Unable to infer GitHub repo: no GitHub remotes found.')
+
+
+def _current_branch_remote(cwd):
+  current_branch = _git_output(cwd, 'rev-parse', '--abbrev-ref', 'HEAD')
+  if current_branch == 'HEAD':
+    return None
+
+  keys = [
+      f'branch.{current_branch}.pushRemote',
+      'remote.pushDefault',
+      f'branch.{current_branch}.remote',
+  ]
+  for key in keys:
+    try:
+      return _git_output(cwd, 'config', '--get', key)
+    except subprocess.CalledProcessError:
+      pass
+  return None
+
+
+def _github_repo_from_remote_name(remote_name, cwd):
+  try:
+    remote_url = _git_output(cwd, 'remote', 'get-url', remote_name)
+  except subprocess.CalledProcessError:
+    return None
+  return _github_repo_from_remote_url(remote_url)
+
+
+def _github_repos_from_remotes(cwd):
+  repos = []
+  for remote_name in _git_output(cwd, 'remote').splitlines():
+    repo = _github_repo_from_remote_name(remote_name, cwd)
+    if repo is not None and repo not in repos:
+      repos.append(repo)
+  return repos
+
+
+def _git_output(cwd, *args):
+  return subprocess.check_output(['git', *args], cwd=cwd, text=True).strip()
+
+
+def _github_repo_from_remote_url(remote_url):
+  match = re.match(
+      r'(?:https://(?:[^/@]+@)?github\.com/|git@github\.com:|ssh://git@github\.com/)'
+      r'([^/]+/[^/]+?)(?:\.git)?$',
+      remote_url,
+  )
+  if match:
+    return match.group(1)
+  return None
+
+
+def ndk():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.ndk if args.ndk else ''

--- a/tools/skia_release/prepare_linux.sh
+++ b/tools/skia_release/prepare_linux.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -y
+apt-get install build-essential software-properties-common -y
+add-apt-repository ppa:ubuntu-toolchain-r/test -y
+apt-get update -y
+apt-get install build-essential software-properties-common -y
+apt-get update
+
+apt-get install gcc-10 g++-10 -y
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+update-alternatives --config gcc
+
+apt-get install git wget -y
+apt-get install ninja-build fontconfig libfontconfig1-dev libglu1-mesa-dev curl zip -y
+
+apt-get install python3.9 -y
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100

--- a/tools/skia_release/prepare_linux_arm.sh
+++ b/tools/skia_release/prepare_linux_arm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -y
+apt-get install binutils build-essential software-properties-common -y
+add-apt-repository ppa:git-core/ppa -y
+add-apt-repository ppa:ubuntu-toolchain-r/test -y
+apt-get update -y
+apt-get install git fontconfig libfontconfig1-dev libglu1-mesa-dev curl wget -y
+
+apt-get install gcc-10 g++-10 -y
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+update-alternatives --config gcc
+
+apt-get install python3.9 -y
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100

--- a/tools/skia_release/prepare_linux_wasm.sh
+++ b/tools/skia_release/prepare_linux_wasm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -y
+apt-get install binutils build-essential -y
+apt-get install software-properties-common -y
+apt-get install git curl wget -y
+
+apt-get install python3.9 -y
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100

--- a/tools/skia_release/release.py
+++ b/tools/skia_release/release.py
@@ -1,0 +1,56 @@
+#! /usr/bin/env python3
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+import common
+
+
+def main():
+  version = common.version()
+  build_type = common.build_type()
+  machine = common.machine()
+  target = common.target()
+  classifier = common.classifier()
+
+  zip_name = 'Skia-' + version + '-' + target + '-' + build_type + '-' + machine + classifier + '.zip'
+  zip_path = common.skia_dir() / zip_name
+  if not zip_path.exists():
+    print('Can\'t find "' + zip_name + '"')
+    return 1
+
+  headers = common.github_headers()
+  releases_url = 'https://api.github.com/repos/' + common.github_repo() + '/releases'
+
+  try:
+    resp = urllib.request.urlopen(
+        urllib.request.Request(releases_url + '/tags/' + version, headers=headers)
+    ).read()
+  except urllib.error.URLError:
+    data = '{"tag_name":"' + version + '","name":"' + version + '"}'
+    resp = urllib.request.urlopen(
+        urllib.request.Request(releases_url, data=data.encode('utf-8'), headers=headers)
+    ).read()
+
+  upload_url = re.match(
+      'https://.*/assets',
+      json.loads(resp.decode('utf-8'))['upload_url'],
+  ).group(0)
+
+  print('Uploading', zip_name, 'to', upload_url)
+  headers['Content-Type'] = 'application/zip'
+  headers['Content-Length'] = os.path.getsize(zip_path)
+  with zip_path.open('rb') as data:
+    urllib.request.urlopen(
+        urllib.request.Request(upload_url + '?name=' + zip_name, data=data, headers=headers)
+    )
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
[SKIKO-1095](https://youtrack.jetbrains.com/issue/SKIKO-1095) Move build scripts from `skia-pack` to `skia` fork

Move the Skiko prebuilts automation from skia-pack into this repo and make the workflow build the current Skia checkout directly.

### Changes in scripts
- Removed the old external-checkout from the scripts (it's the same repo now)
- Do not hardcode SHA for release in workflow (we can just use the current one now)
- Linux arm64 now uses the normal fetched Ninja path instead of commited binary like before