### PR TITLE
Fixed caret snapping inside grapheme clusters

### DIFF
--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -921,8 +921,9 @@ PositionWithAffinity ParagraphImpl::getGlyphPositionAtCoordinate(SkScalar dx, Sk
         //   result.affinity == Affinity::kUpstream ? "up" : "down");
 
         // Snap caret out of the middle of a grapheme cluster (CMP-8054):
-        // e.g. between a base char and a non-spacing mark such as the devanagari
-        // virama. Caret positions inside a grapheme are not selectable.
+        // e.g. between a base char and a non-spacing mark such as the combining
+        // double acute (U+030B) or the devanagari virama (U+094D). Caret positions
+        // inside a grapheme are not selectable.
         if (result.position >= 0) {
             size_t utf16Idx = SkToSizeT(result.position);
             if (utf16Idx < SkToSizeT(fUTF8IndexForUTF16Index.size())) {

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -917,8 +917,23 @@ PositionWithAffinity ParagraphImpl::getGlyphPositionAtCoordinate(SkScalar dx, Sk
         // (or the first one, or the only one - all the same)
 
         auto result = line.getGlyphPositionAtCoordinate(dx);
-        //SkDebugf("getGlyphPositionAtCoordinate(%f, %f): %d %s\n", dx, dy, result.position,
-        //   result.affinity == Affinity::kUpstream ? "up" : "down");
+
+
+        // Snap caret out of the middle of a grapheme cluster (CMP-8054):
+        // e.g. between a base char and a non-spacing mark such as the devanagari
+        // virama. Caret positions inside a grapheme are not selectable.
+        if (result.position >= 0) {
+            size_t utf16Idx = SkToSizeT(result.position);
+            if (utf16Idx < SkToSizeT(fUTF8IndexForUTF16Index.size())) {
+                TextIndex utf8 = fUTF8IndexForUTF16Index[utf16Idx];
+                if (utf8 < fText.size() &&
+                    (fCodeUnitProperties[utf8] & SkUnicode::CodeUnitFlags::kGraphemeStart) == 0) {
+                    TextIndex snapped = this->findNextGraphemeBoundary(utf8);
+                    result = { SkToS32(this->getUTF16Index(snapped)), Affinity::kDownstream };
+                }
+            }
+        }
+
         return result;
     }
 

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -930,7 +930,7 @@ PositionWithAffinity ParagraphImpl::getGlyphPositionAtCoordinate(SkScalar dx, Sk
                 if (utf8 < fText.size() &&
                     (fCodeUnitProperties[utf8] & SkUnicode::CodeUnitFlags::kGraphemeStart) == 0) {
                     TextIndex snapped = this->findNextGraphemeBoundary(utf8);
-                    result = { SkToS32(this->getUTF16Index(snapped)), Affinity::kDownstream };
+                    result = { SkToS32(this->getUTF16Index(snapped)), result.affinity };
                 }
             }
         }

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -917,7 +917,8 @@ PositionWithAffinity ParagraphImpl::getGlyphPositionAtCoordinate(SkScalar dx, Sk
         // (or the first one, or the only one - all the same)
 
         auto result = line.getGlyphPositionAtCoordinate(dx);
-
+        //SkDebugf("getGlyphPositionAtCoordinate(%f, %f): %d %s\n", dx, dy, result.position,
+        //   result.affinity == Affinity::kUpstream ? "up" : "down");
 
         // Snap caret out of the middle of a grapheme cluster (CMP-8054):
         // e.g. between a base char and a non-spacing mark such as the devanagari

--- a/skiko_tests/GetGlyphPositionAtCoordinateTest.cpp
+++ b/skiko_tests/GetGlyphPositionAtCoordinateTest.cpp
@@ -1,0 +1,64 @@
+#include "SkikoTest.h"
+
+#include "include/core/SkScalar.h"
+#include "modules/skparagraph/include/DartTypes.h"
+#include "modules/skparagraph/include/Paragraph.h"
+#include "modules/skparagraph/include/ParagraphStyle.h"
+#include "modules/skparagraph/include/TextStyle.h"
+#include "modules/skparagraph/src/ParagraphBuilderImpl.h"
+#include "modules/skparagraph/utils/TestFontCollection.h"
+#include "modules/skshaper/utils/FactoryHelpers.h"
+#include "modules/skunicode/include/SkUnicode.h"
+#include "tools/Resources.h"
+
+using namespace skia::textlayout;
+
+// Click in the middle of a grapheme cluster formed by base + non-spacing mark.
+// Without the snap-to-grapheme logic in
+// ParagraphImpl::getGlyphPositionAtCoordinate, the hit-test returns the
+// cluster's internal UTF-16 index (between the base and the combining mark),
+// which is not a valid caret position. With the snap, the position is the
+// cluster boundary.
+//
+// Text: "ba\u030Bc" -- 'b', 'a' followed by U+030B (combining double acute), 'c'
+// rendered with Roboto. UTF-16 indices: b(0) a(1) acute(2) c(3); grapheme
+// boundaries are 0, 1, 3, 4. Index 2 is mid-grapheme.
+//
+// The specific pair (a, U+030B) is chosen because Roboto Font has no precomposed
+// glyph for it, so HarfBuzz emits two glyphs with separate cluster IDs and
+// the hit-test can land on the mid-cluster index.
+DEF_TEST_SKIKO(getGlyphPosition_combiningDoubleAcute_notMidGrapheme, reporter) {
+    auto factory = SkShapers::BestAvailable();
+    sk_sp<SkUnicode> unicode = sk_ref_sp<SkUnicode>(factory->getUnicode());
+    sk_sp<TestFontCollection> fonts =
+            sk_make_sp<TestFontCollection>(GetResourcePath("fonts").c_str(), false, true);
+    if (fonts->fontsFound() == 0) {
+        return;
+    }
+
+    ParagraphStyle paragraphStyle;
+    TextStyle textStyle;
+    textStyle.setFontFamilies({SkString("Roboto")});
+    textStyle.setFontSize(50);
+    textStyle.setColor(SK_ColorBLACK);
+
+    const char* text = "ba\u030Bc";
+    ParagraphBuilderImpl builder(paragraphStyle, fonts, unicode);
+    builder.pushStyle(textStyle);
+    builder.addText(text, strlen(text));
+    builder.pop();
+    auto paragraph = builder.Build();
+    paragraph->layout(1000);
+
+    auto boxes = paragraph->getRectsForRange(1, 3, RectHeightStyle::kTight, RectWidthStyle::kTight);
+    if (boxes.empty()) {
+        return;
+    }
+    const SkRect& clusterRect = boxes[0].rect;
+    SkScalar midX = (clusterRect.fLeft + clusterRect.fRight) / 2.0f;
+    SkScalar midY = (clusterRect.fTop + clusterRect.fBottom) / 2.0f;
+
+    auto position = paragraph->getGlyphPositionAtCoordinate(midX, midY).position;
+    REPORTER_ASSERT(reporter, position != 2,
+                    "mid-cluster click returned position %d (mid-grapheme)", position);
+}

--- a/skiko_tests/GetGlyphPositionAtCoordinateTest.cpp
+++ b/skiko_tests/GetGlyphPositionAtCoordinateTest.cpp
@@ -33,6 +33,8 @@ DEF_TEST_SKIKO(getGlyphPosition_combiningDoubleAcute_notMidGrapheme, reporter) {
     sk_sp<TestFontCollection> fonts =
             sk_make_sp<TestFontCollection>(GetResourcePath("fonts").c_str(), false, true);
     if (fonts->fontsFound() == 0) {
+        ERRORF(reporter, "Skiko_getGlyphPosition_combiningDoubleAcute_notMidGrapheme "
+                         "requires fonts in resources/fonts/, none found");
         return;
     }
 
@@ -51,14 +53,15 @@ DEF_TEST_SKIKO(getGlyphPosition_combiningDoubleAcute_notMidGrapheme, reporter) {
     paragraph->layout(1000);
 
     auto boxes = paragraph->getRectsForRange(1, 3, RectHeightStyle::kTight, RectWidthStyle::kTight);
-    if (boxes.empty()) {
-        return;
-    }
-    const SkRect& clusterRect = boxes[0].rect;
-    SkScalar midX = (clusterRect.fLeft + clusterRect.fRight) / 2.0f;
-    SkScalar midY = (clusterRect.fTop + clusterRect.fBottom) / 2.0f;
+    REPORTER_ASSERT(reporter, !boxes.empty(),
+                    "getRectsForRange returned no boxes for the target cluster");
+    if (!boxes.empty()) {
+        const SkRect& clusterRect = boxes[0].rect;
+        SkScalar midX = (clusterRect.fLeft + clusterRect.fRight) / 2.0f;
+        SkScalar midY = (clusterRect.fTop + clusterRect.fBottom) / 2.0f;
 
-    auto position = paragraph->getGlyphPositionAtCoordinate(midX, midY).position;
-    REPORTER_ASSERT(reporter, position != 2,
-                    "mid-cluster click returned position %d (mid-grapheme)", position);
+        auto position = paragraph->getGlyphPositionAtCoordinate(midX, midY).position;
+        REPORTER_ASSERT(reporter, position != 2,
+                        "mid-cluster click returned position %d (mid-grapheme)", position);
+    }
 }

--- a/skiko_tests/skiko_tests.gni
+++ b/skiko_tests/skiko_tests.gni
@@ -1,6 +1,7 @@
 _tests = get_path_info("../skiko_tests", "abspath")
 
 skiko_tests_sources = [
+  "$_tests/GetGlyphPositionAtCoordinateTest.cpp",
   "$_tests/SkikoTestExample.cpp",
   "$_tests/SupportTopRatioBasedVerticalAlignmentTest.cpp",
 ]


### PR DESCRIPTION
Fixed caret snapping inside grapheme clusters in `getGlyphPositionAtCoordinate` method

This logic initially was in [CMP-8054 TextField. Some characters aren't deleted correctly or can't be fully removed](https://youtrack.jetbrains.com/issue/CMP-8054)
The task for moving this here [CMP-8324 Move caret adjustments in complex glyphs fix to Skia](https://youtrack.jetbrains.com/issue/CMP-8324)

[Related PR in the cmp-core](https://github.com/JetBrains/compose-multiplatform-core/pull/3049)