### PR TITLE
[SkParagraph] Align getGlyphPositionAtCoordinate caret hit-testing with Android

### DIFF
--- a/modules/skparagraph/src/TextLine.cpp
+++ b/modules/skparagraph/src/TextLine.cpp
@@ -1506,6 +1506,9 @@ PositionWithAffinity TextLine::getGlyphPositionAtCoordinate(SkScalar dx) {
                 auto graphemes = fOwner->countSurroundingGraphemes({clusterIndex8, clusterEnd8});
 
                 SkScalar center = glyphemePosLeft + glyphemesWidth / 2;
+                if (SkScalarNearlyEqual(center, dx, 0.01f)) {
+                    center = dx;
+                }
                 if (graphemes.size() > 1) {
                     // Calculate the position proportionally based on grapheme count
                     SkScalar averageGraphemeWidth = glyphemesWidth / graphemes.size();
@@ -1515,8 +1518,16 @@ PositionWithAffinity TextLine::getGlyphPositionAtCoordinate(SkScalar dx) {
                                          : SkScalarFloorToInt(delta / averageGraphemeWidth);
                     auto graphemeCenter = glyphemePosLeft + graphemeIndex * averageGraphemeWidth +
                                           averageGraphemeWidth / 2;
+                    if (SkScalarNearlyEqual(graphemeCenter, dx, 0.01f)) {
+                        graphemeCenter = dx;
+                    }
                     auto graphemeUtf8Index = graphemes[graphemeIndex];
-                    if ((dx < graphemeCenter) == context.run->leftToRight()) {
+                    // Tie at exact midpoint → before-char (Android convention). Asymmetric form
+                    // keeps RTL behavior unchanged; only LTR midpoint is affected.
+                    bool dxBeforeCenter = context.run->leftToRight()
+                                                ? (dx <= graphemeCenter)
+                                                : (dx >= graphemeCenter);
+                    if (dxBeforeCenter) {
                         size_t utf16Index = fOwner->getUTF16Index(graphemeUtf8Index);
                         result = { SkToS32(utf16Index), kDownstream };
                     } else {
@@ -1524,7 +1535,9 @@ PositionWithAffinity TextLine::getGlyphPositionAtCoordinate(SkScalar dx) {
                         result = { SkToS32(utf16Index), kUpstream };
                     }
                     // Keep UTF16 index as is
-                } else if ((dx < center) == context.run->leftToRight()) {
+                } else if (context.run->leftToRight()
+                                ? (dx <= center)
+                                : (dx >= center)) {
                     size_t utf16Index = fOwner->getUTF16Index(clusterIndex8);
                     result = { SkToS32(utf16Index), kDownstream };
                 } else {

--- a/modules/skparagraph/src/TextLine.cpp
+++ b/modules/skparagraph/src/TextLine.cpp
@@ -1509,6 +1509,17 @@ PositionWithAffinity TextLine::getGlyphPositionAtCoordinate(SkScalar dx) {
                 if (SkScalarNearlyEqual(center, dx, 0.01f)) {
                     center = dx;
                 }
+
+                // When the run direction opposes the paragraph direction (an embedded RTL
+                // block inside an LTR paragraph, or vice versa), snap hit-test results to
+                // the cluster's paragraph-direction boundaries instead of using run-internal
+                // direction logic. Prevents returning offsets that point "inside" the embedded
+                // run for clicks on its visual edges.
+                const bool paragraphIsLtr =
+                        fOwner->paragraphStyle().getTextDirection() == TextDirection::kLtr;
+                const bool runOpposesParagraph =
+                        (context.run->leftToRight() != paragraphIsLtr);
+
                 if (graphemes.size() > 1) {
                     // Calculate the position proportionally based on grapheme count
                     SkScalar averageGraphemeWidth = glyphemesWidth / graphemes.size();
@@ -1522,19 +1533,45 @@ PositionWithAffinity TextLine::getGlyphPositionAtCoordinate(SkScalar dx) {
                         graphemeCenter = dx;
                     }
                     auto graphemeUtf8Index = graphemes[graphemeIndex];
-                    // Tie at exact midpoint → before-char (Android convention). Asymmetric form
-                    // keeps RTL behavior unchanged; only LTR midpoint is affected.
-                    bool dxBeforeCenter = context.run->leftToRight()
-                                                ? (dx <= graphemeCenter)
-                                                : (dx >= graphemeCenter);
-                    if (dxBeforeCenter) {
-                        size_t utf16Index = fOwner->getUTF16Index(graphemeUtf8Index);
-                        result = { SkToS32(utf16Index), kDownstream };
+                    if (runOpposesParagraph) {
+                        // Paragraph-direction snap at grapheme level.
+                        bool clickOnParaBefore = paragraphIsLtr
+                                                       ? (dx <= graphemeCenter)
+                                                       : (dx >= graphemeCenter);
+                        if (clickOnParaBefore) {
+                            size_t utf16Index = fOwner->getUTF16Index(graphemeUtf8Index);
+                            result = { SkToS32(utf16Index), kUpstream };
+                        } else {
+                            size_t utf16Index = fOwner->getUTF16Index(graphemeUtf8Index + 1);
+                            result = { SkToS32(utf16Index), kDownstream };
+                        }
                     } else {
-                        size_t utf16Index = fOwner->getUTF16Index(graphemeUtf8Index + 1);
-                        result = { SkToS32(utf16Index), kUpstream };
+                        // Tie at exact midpoint → before-char (Android convention).
+                        bool dxBeforeCenter = context.run->leftToRight()
+                                                    ? (dx <= graphemeCenter)
+                                                    : (dx >= graphemeCenter);
+                        if (dxBeforeCenter) {
+                            size_t utf16Index = fOwner->getUTF16Index(graphemeUtf8Index);
+                            result = { SkToS32(utf16Index), kDownstream };
+                        } else {
+                            size_t utf16Index = fOwner->getUTF16Index(graphemeUtf8Index + 1);
+                            result = { SkToS32(utf16Index), kUpstream };
+                        }
                     }
                     // Keep UTF16 index as is
+                } else if (runOpposesParagraph) {
+                    // Paragraph-direction snap at cluster level.
+                    bool clickOnParaBefore =
+                            paragraphIsLtr ? (dx <= center) : (dx >= center);
+                    if (clickOnParaBefore) {
+                        size_t utf16Index = fOwner->getUTF16Index(clusterIndex8);
+                        result = { SkToS32(utf16Index), kUpstream };
+                    } else {
+                        size_t utf16Index = context.run->leftToRight()
+                                                ? fOwner->getUTF16Index(clusterEnd8)
+                                                : fOwner->getUTF16Index(clusterIndex8) + 1;
+                        result = { SkToS32(utf16Index), kDownstream };
+                    }
                 } else if (context.run->leftToRight()
                                 ? (dx <= center)
                                 : (dx >= center)) {

--- a/skiko_tests/GetGlyphPositionAtCoordinateTest.cpp
+++ b/skiko_tests/GetGlyphPositionAtCoordinateTest.cpp
@@ -65,3 +65,104 @@ DEF_TEST_SKIKO(getGlyphPosition_combiningDoubleAcute_notMidGrapheme, reporter) {
                         "mid-cluster click returned position %d (mid-grapheme)", position);
     }
 }
+
+// Tie-break: when the click x lands exactly on the geometric midpoint of a glyph,
+// the two candidate caret positions (before-char and after-char) are equidistant.
+// Android's Layout.getOffsetForHorizontal resolves this tie to the before-char side
+// (Math.abs-distance comparison with strict `<` update keeps the earlier-encountered
+// offset = the one to the visual left for LTR). Skia historically resolved it to
+// after-char via `(dx < center) == leftToRight()`, which strictly fails at midpoint
+// and falls through to the else branch.
+//
+// This test pins the Android-compatible behavior: clicking at the exact horizontal
+// midpoint of glyph 'a' in "abc" yields offset 0 (before 'a'), not 1 (after 'a').
+DEF_TEST_SKIKO(getGlyphPosition_midpointTieBreak_ltr_landsBeforeChar, reporter) {
+    auto factory = SkShapers::BestAvailable();
+    sk_sp<SkUnicode> unicode = sk_ref_sp<SkUnicode>(factory->getUnicode());
+    sk_sp<TestFontCollection> fonts =
+            sk_make_sp<TestFontCollection>(GetResourcePath("fonts").c_str(), false, true);
+    if (fonts->fontsFound() == 0) {
+        ERRORF(reporter, "Skiko_getGlyphPosition_midpointTieBreak_ltr_landsBeforeChar "
+                         "requires fonts in resources/fonts/, none found");
+        return;
+    }
+
+    ParagraphStyle paragraphStyle;
+    TextStyle textStyle;
+    textStyle.setFontFamilies({SkString("Roboto")});
+    textStyle.setFontSize(50);
+    textStyle.setColor(SK_ColorBLACK);
+
+    const char* text = "abc";
+    ParagraphBuilderImpl builder(paragraphStyle, fonts, unicode);
+    builder.pushStyle(textStyle);
+    builder.addText(text, strlen(text));
+    builder.pop();
+    auto paragraph = builder.Build();
+    paragraph->layout(1000);
+
+    // Locate the exact midpoint of glyph 'a' via getRectsForRange.
+    auto boxes = paragraph->getRectsForRange(0, 1, RectHeightStyle::kTight, RectWidthStyle::kTight);
+    REPORTER_ASSERT(reporter, !boxes.empty(),
+                    "getRectsForRange returned no boxes for glyph 'a'");
+    if (!boxes.empty()) {
+        const SkRect& aRect = boxes[0].rect;
+        SkScalar midX = (aRect.fLeft + aRect.fRight) / 2.0f;
+        SkScalar midY = (aRect.fTop + aRect.fBottom) / 2.0f;
+
+        auto position = paragraph->getGlyphPositionAtCoordinate(midX, midY).position;
+        REPORTER_ASSERT(reporter, position == 0,
+                        "midpoint click returned position %d, expected 0 (before-char)", position);
+    }
+}
+
+// Companion regression test for the RTL side of midpoint tie-break: Skia historically
+// returned the before-logical offset at the exact midpoint of an RTL glyph (via the
+// original `(dx < center) == leftToRight()` evaluating to T == T → if-branch at midpoint),
+// and the asymmetric fix preserves this behavior — only the LTR side is changed. This test
+// pins the RTL outcome so future refactors don't accidentally flip it.
+//
+// Text "אבג" laid out as RTL; clicking the exact horizontal midpoint of the middle glyph
+// ב (UTF-16 index 1) should yield offset 1 (before-ב logically = visually right of ב).
+DEF_TEST_SKIKO(getGlyphPosition_midpointTieBreak_rtl_landsBeforeChar, reporter) {
+    auto factory = SkShapers::BestAvailable();
+    sk_sp<SkUnicode> unicode = sk_ref_sp<SkUnicode>(factory->getUnicode());
+    sk_sp<TestFontCollection> fonts =
+            sk_make_sp<TestFontCollection>(GetResourcePath("fonts").c_str(), false, true);
+    if (fonts->fontsFound() == 0) {
+        ERRORF(reporter, "Skiko_getGlyphPosition_midpointTieBreak_rtl_landsBeforeChar "
+                         "requires fonts in resources/fonts/, none found");
+        return;
+    }
+
+    ParagraphStyle paragraphStyle;
+    paragraphStyle.setTextDirection(TextDirection::kRtl);
+    TextStyle textStyle;
+    textStyle.setFontFamilies({SkString("Roboto")});
+    textStyle.setFontSize(50);
+    textStyle.setColor(SK_ColorBLACK);
+
+    // אבג — Hebrew Aleph, Bet, Gimel. Escaped to avoid relying on source-file encoding.
+    const char* text = "אבג";
+    ParagraphBuilderImpl builder(paragraphStyle, fonts, unicode);
+    builder.pushStyle(textStyle);
+    builder.addText(text, strlen(text));
+    builder.pop();
+    auto paragraph = builder.Build();
+    paragraph->layout(1000);
+
+    // Locate the exact midpoint of ב (the middle glyph, UTF-16 index 1).
+    auto boxes = paragraph->getRectsForRange(1, 2, RectHeightStyle::kTight, RectWidthStyle::kTight);
+    REPORTER_ASSERT(reporter, !boxes.empty(),
+                    "getRectsForRange returned no boxes for ב");
+    if (!boxes.empty()) {
+        const SkRect& betRect = boxes[0].rect;
+        SkScalar midX = (betRect.fLeft + betRect.fRight) / 2.0f;
+        SkScalar midY = (betRect.fTop + betRect.fBottom) / 2.0f;
+
+        auto position = paragraph->getGlyphPositionAtCoordinate(midX, midY).position;
+        REPORTER_ASSERT(reporter, position == 1,
+                        "RTL midpoint click returned position %d, expected 1 (before-logical)",
+                        position);
+    }
+}

--- a/skiko_tests/GetGlyphPositionAtCoordinateTest.cpp
+++ b/skiko_tests/GetGlyphPositionAtCoordinateTest.cpp
@@ -166,3 +166,67 @@ DEF_TEST_SKIKO(getGlyphPosition_midpointTieBreak_rtl_landsBeforeChar, reporter) 
                         position);
     }
 }
+
+// BiDi-boundary hit-test: clicking inside an embedded opposite-direction run should
+// snap to the cluster's paragraph-direction boundary, matching Android's
+// closest-primary-direction-caret algorithm. Skia historically returned offsets pointing
+// "inside" the embedded run via its run-internal RTL hit-test logic — this test pins
+// the fix that prefers paragraph-direction boundaries.
+//
+// Text "aא." is laid out LTR (first-strong 'a'); א is a single-cluster RTL run embedded
+// inside. Clicking on the LEFT visual half of א should yield offset 1 (= boundary
+// between 'a' and א in paragraph reading direction), not offset 2 (= boundary inside
+// the RTL run between א and '.'). The two offsets encode the same visual caret position
+// but differ in which (offset, affinity) pair we return.
+DEF_TEST_SKIKO(getGlyphPosition_bidiBoundary_embeddedRTL_snapsToParagraphDirection, reporter) {
+    auto factory = SkShapers::BestAvailable();
+    sk_sp<SkUnicode> unicode = sk_ref_sp<SkUnicode>(factory->getUnicode());
+    sk_sp<TestFontCollection> fonts =
+            sk_make_sp<TestFontCollection>(GetResourcePath("fonts").c_str(), false, true);
+    if (fonts->fontsFound() == 0) {
+        ERRORF(reporter,
+               "Skiko_getGlyphPosition_bidiBoundary_embeddedRTL_snapsToParagraphDirection "
+               "requires fonts in resources/fonts/, none found");
+        return;
+    }
+
+    ParagraphStyle paragraphStyle;
+    paragraphStyle.setTextDirection(TextDirection::kLtr);
+    TextStyle textStyle;
+    textStyle.setFontFamilies({SkString("Roboto")});
+    textStyle.setFontSize(50);
+    textStyle.setColor(SK_ColorBLACK);
+
+    // "aא." — 'a' (LTR), Aleph (RTL embedded), '.' (neutral). UTF-16 indices: a(0), א(1), .(2).
+    const char* text = "aא.";
+    ParagraphBuilderImpl builder(paragraphStyle, fonts, unicode);
+    builder.pushStyle(textStyle);
+    builder.addText(text, strlen(text));
+    builder.pop();
+    auto paragraph = builder.Build();
+    paragraph->layout(1000);
+
+    // Get the visual rect of א and probe its visual halves.
+    auto boxes = paragraph->getRectsForRange(1, 2, RectHeightStyle::kTight, RectWidthStyle::kTight);
+    REPORTER_ASSERT(reporter, !boxes.empty(),
+                    "getRectsForRange returned no boxes for א");
+    if (!boxes.empty()) {
+        const SkRect& alephRect = boxes[0].rect;
+        SkScalar midY = (alephRect.fTop + alephRect.fBottom) / 2.0f;
+        SkScalar quarterWidth = (alephRect.fRight - alephRect.fLeft) / 4.0f;
+
+        // Click on visual LEFT half (1px inside the left edge → paragraph-before of α).
+        SkScalar leftQuarter = alephRect.fLeft + quarterWidth;
+        auto leftPos = paragraph->getGlyphPositionAtCoordinate(leftQuarter, midY).position;
+        REPORTER_ASSERT(reporter, leftPos == 1,
+                        "left-half click in embedded RTL returned position %d, expected 1 "
+                        "(paragraph-direction before α)", leftPos);
+
+        // Click on visual RIGHT half → paragraph-after of α.
+        SkScalar rightQuarter = alephRect.fLeft + 3 * quarterWidth;
+        auto rightPos = paragraph->getGlyphPositionAtCoordinate(rightQuarter, midY).position;
+        REPORTER_ASSERT(reporter, rightPos == 2,
+                        "right-half click in embedded RTL returned position %d, expected 2 "
+                        "(paragraph-direction after α)", rightPos);
+    }
+}


### PR DESCRIPTION
Fixes: [CMP-8594 Fix `Paragraph.getOffsetForPosition` behavour in corner cases](https://youtrack.jetbrains.com/issue/CMP-8594)

Brings two corner cases of `ParagraphImpl::getGlyphPositionAtCoordinate` (via `TextLine`) in line with how Android's `Layout.getOffsetForHorizontal` resolves caret offsets:

  - Midpoint tie-break: When the click `x` lands exactly on a glyph's geometric midpoint, the two candidate offsets (before-char / after-char) are equidistant. Skia historically resolved this tie to after-char (`(dx < center) == leftToRight()` falls through to the else branch at the exact midpoint). This now resolves to before-char, matching Android. The fix is asymmetric — only the LTR midpoint is affected, RTL behavior is intentionally preserved — and applies the same tie rule to per-grapheme midpoints within a multi-grapheme cluster.

  - BiDi boundary hit-testing: When a run's direction opposes the paragraph direction (an embedded RTL run inside an LTR paragraph, or vice versa), hit-test results are snapped to the cluster's paragraph-direction boundaries instead of using run-internal direction logic. This matches Android's closest-primary-direction-caret algorithm and prevents returning offsets that point "inside" the embedded run for clicks on its visual edges.

## Tests
Added to `skiko_tests/GetGlyphPositionAtCoordinateTest.cpp`:
- `getGlyphPosition_midpointTieBreak_ltr_landsBeforeChar` - LTR midpoint → before-char.
- `getGlyphPosition_midpointTieBreak_rtl_landsBeforeChar` - pins RTL midpoint (unchanged).
- `getGlyphPosition_bidiBoundary_embeddedRTL_snapsToParagraphDirection` - left/right half of an embedded RTL cluster resolve to the paragraph-direction boundaries.