### PR TITLE
[SkParagraph] Center letter-spaced text by its glyph ink

### DIFF
--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -642,12 +642,13 @@ void ParagraphImpl::breakShapedTextIntoLines(SkScalar maxWidth) {
         auto clusterRangeWithGhosts = ClusterRange(0, this->clusters().size() - 1);
         TextIndent indent = this->paragraphStyle().getTextIndent();
         SkScalar lineIndent = indent.getFirstLine();
-        this->addLine(SkPoint::Make(0, 0), lineIndent, advance,
+        auto& line = this->addLine(SkPoint::Make(0, 0), lineIndent, advance,
                       textExcludingSpaces, textRange, textRange,
                       clusterRange, clusterRangeWithGhosts, run.advance().x(),
                       metrics);
 
-        fLongestLine = nearlyZero(advance.fX) ? run.advance().fX : advance.fX;
+        // line.width() has the trailing letter spacing trimmed off; advance.fX still has it.
+        fLongestLine = nearlyZero(line.width()) ? run.advance().fX : line.width();
         fHeight = advance.fY;
         fWidth = maxWidth;
         fMaxIntrinsicWidth = run.advance().fX;

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -643,9 +643,9 @@ void ParagraphImpl::breakShapedTextIntoLines(SkScalar maxWidth) {
         TextIndent indent = this->paragraphStyle().getTextIndent();
         SkScalar lineIndent = indent.getFirstLine();
         auto& line = this->addLine(SkPoint::Make(0, 0), lineIndent, advance,
-                      textExcludingSpaces, textRange, textRange,
-                      clusterRange, clusterRangeWithGhosts, run.advance().x(),
-                      metrics);
+                                   textExcludingSpaces, textRange, textRange,
+                                   clusterRange, clusterRangeWithGhosts, run.advance().x(),
+                                   metrics);
 
         // line.width() has the trailing letter spacing trimmed off; advance.fX still has it.
         fLongestLine = nearlyZero(line.width()) ? run.advance().fX : line.width();

--- a/modules/skparagraph/src/TextLine.cpp
+++ b/modules/skparagraph/src/TextLine.cpp
@@ -304,6 +304,22 @@ void TextLine::format(TextAlign align, SkScalar maxWidth) {
     }
 
     bool isRtl = fOwner->paragraphStyle().getTextDirection() == TextDirection::kRtl;
+
+    // Letter spacing is added *after* every glyph (see Run::addLetterSpacesEvenly), including the
+    // last one in the line, and that trailing gap is part of the advance returned by width(). It
+    // is empty space with no glyph behind it, so counting it for center/right alignment pushes the
+    // visible glyphs off position - e.g. centred text ends up shifted left by letterSpacing / 2.
+    // Exclude the trailing letter spacing of the line's last cluster from the alignment shift so
+    // the glyph ink, not the trailing gap, is aligned.
+    SkScalar trailingLetterSpacing = 0;
+    if (fClusterRange.width() > 0) {
+        // getHalfLetterSpacing() == letterSpacing / 2; the full value is the trailing gap.
+        trailingLetterSpacing = fOwner->cluster(fClusterRange.end - 1).getHalfLetterSpacing() * 2;
+    }
+    // For LTR the trailing gap is on the visual right; for RTL it is on the visual left, so the
+    // correction is mirrored.
+    SkScalar centerDelta = delta + (isRtl ? -trailingLetterSpacing : trailingLetterSpacing);
+
     if (align == TextAlign::kJustify) {
         if (!this->endsWithHardLineBreak()) {
             this->justify(maxWidth - fIndent);
@@ -316,9 +332,9 @@ void TextLine::format(TextAlign align, SkScalar maxWidth) {
             fShift = fIndent;
         }
     } else if (align == TextAlign::kRight) {
-        fShift = delta;
+        fShift = isRtl ? delta : delta + trailingLetterSpacing;
     } else if (align == TextAlign::kCenter) {
-        fShift = delta / 2 + (isRtl ? 0 : fIndent);
+        fShift = centerDelta / 2 + (isRtl ? 0 : fIndent);
     } else if (align == TextAlign::kLeft) {
         fShift = fIndent;
     }

--- a/modules/skparagraph/src/TextLine.cpp
+++ b/modules/skparagraph/src/TextLine.cpp
@@ -185,10 +185,9 @@ TextLine::TextLine(ParagraphImpl* owner,
         }
     }
 
-    // Letter spacing is added after every glyph, so the last glyph on the line carries a trailing
-    // gap with nothing behind it. Drop it from the advance so width() measures the ink; otherwise
-    // it would push centered/right-aligned text off by half the letter spacing. Cursive runs never
-    // get letter spacing added to their advance (the half-spacing is still recorded), so skip them.
+    // Letter spacing is added after every glyph, including the last, so the advance ends with an
+    // empty gap. Drop it so width() is the ink width. Cursive runs get no letter spacing (but still
+    // record it), so skip them.
     if (fClusterRange.width() > 0) {
         auto& lastCluster = fOwner->cluster(fClusterRange.end - 1);
         if (!lastCluster.run().isCursiveScript()) {

--- a/modules/skparagraph/src/TextLine.cpp
+++ b/modules/skparagraph/src/TextLine.cpp
@@ -184,6 +184,17 @@ TextLine::TextLine(ParagraphImpl* owner,
             break;
         }
     }
+
+    // Letter spacing is added after every glyph, so the last glyph on the line carries a trailing
+    // gap with nothing behind it. Drop it from the advance so width() measures the ink; otherwise
+    // it would push centered/right-aligned text off by half the letter spacing. Cursive runs never
+    // get letter spacing added to their advance (the half-spacing is still recorded), so skip them.
+    if (fClusterRange.width() > 0) {
+        auto& lastCluster = fOwner->cluster(fClusterRange.end - 1);
+        if (!lastCluster.run().isCursiveScript()) {
+            fAdvance.fX -= lastCluster.getHalfLetterSpacing() * 2;
+        }
+    }
 }
 
 void TextLine::paint(ParagraphPainter* painter, SkScalar x, SkScalar y) {
@@ -304,22 +315,6 @@ void TextLine::format(TextAlign align, SkScalar maxWidth) {
     }
 
     bool isRtl = fOwner->paragraphStyle().getTextDirection() == TextDirection::kRtl;
-
-    // Letter spacing is added *after* every glyph (see Run::addLetterSpacesEvenly), including the
-    // last one in the line, and that trailing gap is part of the advance returned by width(). It
-    // is empty space with no glyph behind it, so counting it for center/right alignment pushes the
-    // visible glyphs off position - e.g. centred text ends up shifted left by letterSpacing / 2.
-    // Exclude the trailing letter spacing of the line's last cluster from the alignment shift so
-    // the glyph ink, not the trailing gap, is aligned.
-    SkScalar trailingLetterSpacing = 0;
-    if (fClusterRange.width() > 0) {
-        // getHalfLetterSpacing() == letterSpacing / 2; the full value is the trailing gap.
-        trailingLetterSpacing = fOwner->cluster(fClusterRange.end - 1).getHalfLetterSpacing() * 2;
-    }
-    // For LTR the trailing gap is on the visual right; for RTL it is on the visual left, so the
-    // correction is mirrored.
-    SkScalar centerDelta = delta + (isRtl ? -trailingLetterSpacing : trailingLetterSpacing);
-
     if (align == TextAlign::kJustify) {
         if (!this->endsWithHardLineBreak()) {
             this->justify(maxWidth - fIndent);
@@ -332,9 +327,9 @@ void TextLine::format(TextAlign align, SkScalar maxWidth) {
             fShift = fIndent;
         }
     } else if (align == TextAlign::kRight) {
-        fShift = isRtl ? delta : delta + trailingLetterSpacing;
+        fShift = delta;
     } else if (align == TextAlign::kCenter) {
-        fShift = centerDelta / 2 + (isRtl ? 0 : fIndent);
+        fShift = delta / 2 + (isRtl ? 0 : fIndent);
     } else if (align == TextAlign::kLeft) {
         fShift = fIndent;
     }

--- a/modules/skparagraph/tests/SkParagraphTest.cpp
+++ b/modules/skparagraph/tests/SkParagraphTest.cpp
@@ -2047,18 +2047,76 @@ UNIX_ONLY_TEST(SkParagraph_CenterAlignParagraph, reporter) {
     REPORTER_ASSERT(reporter,
                     SkScalarNearlyEqual(impl->lines()[13].offset().fY, expected_y, epsilon));
 
+    // Centred text centres the glyph ink, not the advance box. The line advance includes the
+    // letter spacing added after the last glyph (see TextLine::format), so the box is shifted
+    // right by letterSpacing / 2 and its right and left margins differ by exactly the trailing
+    // letter spacing. calculate() returns (rightMargin - leftMargin).
+    const SkScalar trailingSpacing = text_style.getLetterSpacing();
     auto calculate = [](const TextLine& line) -> SkScalar {
         return TestCanvasWidth - 100 - (line.offset().fX * 2 + line.width());
     };
 
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[0]), 0, epsilon));
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[1]), 0, epsilon));
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[2]), 0, epsilon));
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[3]), 0, epsilon));
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[13]), 0, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[0]), -trailingSpacing, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[1]), -trailingSpacing, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[2]), -trailingSpacing, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[3]), -trailingSpacing, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[13]), -trailingSpacing, epsilon));
 
     REPORTER_ASSERT(reporter,
                     paragraph_style.getTextAlign() == impl->paragraphStyle().getTextAlign());
+}
+
+// Letter spacing is added *after* the last glyph too and folded into the line advance. Centred
+// text must centre the glyph ink, not that empty trailing gap. Here we render and check that the
+// painted ink is horizontally centred. (getRectsForRange can't be used: its box includes the gap.)
+UNIX_ONLY_TEST(SkParagraph_CenterAlignLetterSpacing, reporter) {
+    sk_sp<ResourceFontCollection> fontCollection = sk_make_sp<ResourceFontCollection>();
+    SKIP_IF_FONTS_NOT_FOUND(reporter, fontCollection)
+
+    const char* text = "WW";
+    const size_t len = strlen(text);
+    const int width = 400;
+    const int height = 80;
+    const SkScalar letterSpacing = 40;
+
+    ParagraphStyle paragraph_style;
+    paragraph_style.setTextAlign(TextAlign::kCenter);
+    ParagraphBuilderImpl builder(paragraph_style, fontCollection, get_unicode());
+
+    TextStyle text_style;
+    text_style.setFontFamilies({SkString("Roboto")});
+    text_style.setFontSize(40);
+    text_style.setLetterSpacing(letterSpacing);
+    text_style.setColor(SK_ColorBLACK);
+    builder.pushStyle(text_style);
+    builder.addText(text, len);
+    builder.pop();
+
+    auto paragraph = builder.Build();
+    paragraph->layout(width);
+
+    SkBitmap bitmap;
+    bitmap.allocN32Pixels(width, height);
+    bitmap.eraseColor(SK_ColorWHITE);
+    SkCanvas canvas(bitmap);
+    paragraph->paint(&canvas, 0, 0);
+
+    // Horizontal span of painted (dark) pixels = the glyph ink, which excludes the trailing gap.
+    int minInkX = width;
+    int maxInkX = -1;
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            if (SkColorGetR(bitmap.getColor(x, y)) < 128) {
+                minInkX = std::min(minInkX, x);
+                maxInkX = std::max(maxInkX, x);
+            }
+        }
+    }
+    REPORTER_ASSERT(reporter, maxInkX > minInkX);
+
+    // Without the fix the ink is shifted left by letterSpacing / 2 (= 20px here).
+    SkScalar inkCenter = (minInkX + maxInkX) / 2.0f;
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(inkCenter, width / 2.0f, 2.0f));
 }
 
 UNIX_ONLY_TEST(SkParagraph_JustifyAlignParagraph, reporter) {

--- a/modules/skparagraph/tests/SkParagraphTest.cpp
+++ b/modules/skparagraph/tests/SkParagraphTest.cpp
@@ -2047,20 +2047,15 @@ UNIX_ONLY_TEST(SkParagraph_CenterAlignParagraph, reporter) {
     REPORTER_ASSERT(reporter,
                     SkScalarNearlyEqual(impl->lines()[13].offset().fY, expected_y, epsilon));
 
-    // Centred text centres the glyph ink, not the advance box. The line advance includes the
-    // letter spacing added after the last glyph (see TextLine::format), so the box is shifted
-    // right by letterSpacing / 2 and its right and left margins differ by exactly the trailing
-    // letter spacing. calculate() returns (rightMargin - leftMargin).
-    const SkScalar trailingSpacing = text_style.getLetterSpacing();
     auto calculate = [](const TextLine& line) -> SkScalar {
         return TestCanvasWidth - 100 - (line.offset().fX * 2 + line.width());
     };
 
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[0]), -trailingSpacing, epsilon));
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[1]), -trailingSpacing, epsilon));
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[2]), -trailingSpacing, epsilon));
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[3]), -trailingSpacing, epsilon));
-    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[13]), -trailingSpacing, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[0]), 0, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[1]), 0, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[2]), 0, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[3]), 0, epsilon));
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(calculate(impl->lines()[13]), 0, epsilon));
 
     REPORTER_ASSERT(reporter,
                     paragraph_style.getTextAlign() == impl->paragraphStyle().getTextAlign());
@@ -2117,6 +2112,61 @@ UNIX_ONLY_TEST(SkParagraph_CenterAlignLetterSpacing, reporter) {
     // Without the fix the ink is shifted left by letterSpacing / 2 (= 20px here).
     SkScalar inkCenter = (minInkX + maxInkX) / 2.0f;
     REPORTER_ASSERT(reporter, SkScalarNearlyEqual(inkCenter, width / 2.0f, 2.0f));
+}
+
+// Cursive scripts (Arabic here) never get letter spacing applied to their glyphs, but the
+// per-cluster half letter spacing is still recorded. The trailing-gap trim in the TextLine
+// ctor must skip them, otherwise centred cursive text would be shifted by letterSpacing / 2.
+// Guard against that regression: letter spacing must not move centred Arabic text. We compare
+// the painted ink of the same text laid out with and without letter spacing.
+UNIX_ONLY_TEST(SkParagraph_CenterAlignLetterSpacingRTL, reporter) {
+    sk_sp<ResourceFontCollection> fontCollection = sk_make_sp<ResourceFontCollection>();
+    SKIP_IF_FONTS_NOT_FOUND(reporter, fontCollection)
+
+    // "مرحبا"
+    const char* text = "\xD9\x85\xD8\xB1\xD8\xAD\xD8\xA8\xD8\xA7";
+    const int width = 400;
+    const int height = 120;
+
+    auto inkCenter = [&](SkScalar letterSpacing) -> SkScalar {
+        ParagraphStyle paragraph_style;
+        paragraph_style.setTextAlign(TextAlign::kCenter);
+        paragraph_style.setTextDirection(TextDirection::kRtl);
+        ParagraphBuilderImpl builder(paragraph_style, fontCollection, get_unicode());
+
+        TextStyle text_style;
+        text_style.setFontFamilies({SkString("Noto Naskh Arabic")});
+        text_style.setFontSize(40);
+        text_style.setLetterSpacing(letterSpacing);
+        text_style.setColor(SK_ColorBLACK);
+        builder.pushStyle(text_style);
+        builder.addText(text, strlen(text));
+        builder.pop();
+
+        auto paragraph = builder.Build();
+        paragraph->layout(width);
+
+        SkBitmap bitmap;
+        bitmap.allocN32Pixels(width, height);
+        bitmap.eraseColor(SK_ColorWHITE);
+        SkCanvas canvas(bitmap);
+        paragraph->paint(&canvas, 0, 0);
+
+        int minInkX = width, maxInkX = -1;
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                if (SkColorGetR(bitmap.getColor(x, y)) < 128) {
+                    minInkX = std::min(minInkX, x);
+                    maxInkX = std::max(maxInkX, x);
+                }
+            }
+        }
+        REPORTER_ASSERT(reporter, maxInkX > minInkX);
+        return (minInkX + maxInkX) / 2.0f;
+    };
+
+    // Letter spacing is a no-op for cursive text, so both must centre at the same place.
+    REPORTER_ASSERT(reporter, SkScalarNearlyEqual(inkCenter(40), inkCenter(0), 1.0f));
 }
 
 UNIX_ONLY_TEST(SkParagraph_JustifyAlignParagraph, reporter) {

--- a/modules/skparagraph/tests/SkParagraphTest.cpp
+++ b/modules/skparagraph/tests/SkParagraphTest.cpp
@@ -2114,11 +2114,8 @@ UNIX_ONLY_TEST(SkParagraph_CenterAlignLetterSpacing, reporter) {
     REPORTER_ASSERT(reporter, SkScalarNearlyEqual(inkCenter, width / 2.0f, 2.0f));
 }
 
-// Cursive scripts (Arabic here) never get letter spacing applied to their glyphs, but the
-// per-cluster half letter spacing is still recorded. The trailing-gap trim in the TextLine
-// ctor must skip them, otherwise centred cursive text would be shifted by letterSpacing / 2.
-// Guard against that regression: letter spacing must not move centred Arabic text. We compare
-// the painted ink of the same text laid out with and without letter spacing.
+// Letter spacing is a no-op for cursive text, so it must not move centred Arabic. Guards against
+// the trailing-gap trim wrongly firing on cursive runs.
 UNIX_ONLY_TEST(SkParagraph_CenterAlignLetterSpacingRTL, reporter) {
     sk_sp<ResourceFontCollection> fontCollection = sk_make_sp<ResourceFontCollection>();
     SKIP_IF_FONTS_NOT_FOUND(reporter, fontCollection)


### PR DESCRIPTION
Fixes [CMP-8469: Text not centred on iOS with letter-spacing](https://youtrack.jetbrains.com/issue/CMP-8469/Text-not-centred-on-iOS-with-letterspacing).

## Problem

Centre-aligned (and right-aligned) text with non-zero `letterSpacing` renders shifted toward the start of the line. `Run::addLetterSpacesEvenly` adds a full `letterSpacing` *after* every glyph — including the last glyph in a line — and that trailing gap is included in the line advance (`TextLine::width()`). `TextLine::format()` then computes the center/right alignment shift from that advance, so the empty trailing gap pushes the visible glyphs off position: centred text ends up shifted left by `letterSpacing / 2`.

## Fix

Trim the trailing letter spacing of the line's last cluster from the **line advance** when the line is built (`TextLine` constructor), so `width()` measures the glyph ink rather than the advance box. Because `width()` feeds `format()` (alignment `fShift`), clipping (`measureTextInsideOneRun`), `getRectsForRange`, longest-line, etc., fixing it at the advance corrects alignment, clipping and width consistently in one place. `format()` needs no change and no RTL-specific handling.

Cursive runs are skipped: they never get letter spacing added to their advance (the half-spacing is still recorded), so trimming them would shift correctly-centred cursive text (e.g. Arabic) by `letterSpacing / 2`.

## Behavior change (please review)

`width()` (and therefore reported line/longest-line width and clip bounds) no longer includes the empty trailing letter-spacing gap. This is the intended fix but is Flutter-visible, so worth a careful look.

## Testing

Built `dm` and ran the skparagraph tests:

- `SkParagraph_CenterAlignLetterSpacing` (LTR): renders centred letter-spaced text and asserts the painted ink span is horizontally centred (ink centre 180 → 200 for a 400px container with `letterSpacing=40`).
- `SkParagraph_CenterAlignLetterSpacingRTL` (Arabic, cursive): asserts letter spacing does not move centred cursive text; fails if the trim wrongly fires on cursive runs.
- `SkParagraph_CenterAlignParagraph`: back to asserting symmetric margins (`0`), since the advance box is symmetric again once the trailing gap is trimmed.
- Non-cursive RTL (Hebrew) centring verified locally; not automated, since no Hebrew face is referenced in the test font set.
