### PR TITLE
Extract skottie into separate module

### DIFF
--- a/gn/skia/BUILD.gn
+++ b/gn/skia/BUILD.gn
@@ -810,7 +810,9 @@ if (is_wasm) {
     config("wasm") {
       common = [
         "--sysroot=$skia_emsdk_dir/upstream/emscripten/cache/sysroot",
-        "-pthread",
+        # This was introduced after m146, but it breaks Skiko's Emscripten
+        # MAIN_MODULE=2 runtime with memory access out of bounds failures
+        # "-pthread",
       ]
       cflags = common
       ldflags = common

--- a/modules/jsonreader/BUILD.gn
+++ b/modules/jsonreader/BUILD.gn
@@ -7,6 +7,7 @@ import("../../gn/skia.gni")
 
 skia_component("jsonreader") {
   import("jsonreader.gni")
+  complete_static_lib = false
   sources = skia_jsonreader_sources
   deps = [ "../..:skia" ]
 }

--- a/modules/skottie/BUILD.gn
+++ b/modules/skottie/BUILD.gn
@@ -16,6 +16,7 @@ if (skia_enable_skottie) {
 
   skia_component("skottie") {
     check_includes = false
+    complete_static_lib = false
     import("skottie.gni")
     public_configs = [ ":public_config" ]
     public = skia_skottie_public

--- a/modules/sksg/BUILD.gn
+++ b/modules/sksg/BUILD.gn
@@ -11,6 +11,7 @@ config("public_config") {
 
 skia_component("sksg") {
   check_includes = false
+  complete_static_lib = false
   import("sksg.gni")
   public_configs = [ ":public_config" ]
   sources = skia_sksg_sources

--- a/tools/skia_release/build.py
+++ b/tools/skia_release/build.py
@@ -108,6 +108,11 @@ def main():
       'extra_cflags_cc=[]',
   ]
 
+  if target == 'windows':
+    args += ['extra_cflags+=["/clang:-fvisibility=default"]']
+  else:
+    args += ['extra_cflags+=["-fvisibility=default"]']
+
   if is_macos or is_ios or is_tvos:
     if is_macos:
       args += ['skia_use_fonthost_mac=true']


### PR DESCRIPTION
Required changes for https://github.com/JetBrains/skiko/pull/1213


This PR includes:
 - Making skottie, jsonreader and sksg static archives without its dependencies
 - Compiling skia with default visibility
 - Disabling `pthread` for WASM target introduced in m146 as a part of [initial standalone WASM gn build](https://github.com/google/skia/commit/e979274a45e6e0f9a7939d3d0340e46492a29721)