### PR TITLE
Add Dawn headers for archives when Skia Graphite Dawn is used

### DIFF
--- a/.github/workflows/build_for_skiko.yml
+++ b/.github/workflows/build_for_skiko.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Print Xcode version
         run: xcodebuild -version
       - run: python3 tools/skia_release/build.py --skia-dir . --build-type ${{ matrix.build_type }} --target ${{ matrix.target }} --machine ${{ matrix.machine }} --gpu-as-extension --enable-graphite ${{ matrix.target == 'macos' && '--enable-graphite-dawn' || '' }}
-      - run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target ${{ matrix.target }} --machine ${{ matrix.machine }}
+      - run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target ${{ matrix.target }} --machine ${{ matrix.machine }} ${{ matrix.target == 'macos' && '--enable-graphite-dawn' || '' }}
       - uses: actions/upload-artifact@v4
         if: ${{ needs.prepare.outputs.should_release == 'true' }}
         with:
@@ -142,7 +142,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: python3 tools/skia_release/build.py --skia-dir . --target wasm --machine wasm --build-type ${{ matrix.build_type }} --gpu-as-extension --enable-graphite-dawn
-      - run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target wasm --machine wasm --build-type ${{ matrix.build_type }}
+      - run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --target wasm --machine wasm --build-type ${{ matrix.build_type }} --enable-graphite-dawn
       - uses: actions/upload-artifact@v4
         if: ${{ needs.prepare.outputs.should_release == 'true' }}
         with:
@@ -250,7 +250,7 @@ jobs:
       - shell: bash
         run: python3 tools/skia_release/build.py --skia-dir . --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }} --gpu-as-extension --enable-graphite-dawn
       - shell: bash
-        run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+        run: python3 tools/skia_release/archive.py --skia-dir . --version ${{ needs.prepare.outputs.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }} --enable-graphite-dawn
       - uses: actions/upload-artifact@v4
         if: ${{ needs.prepare.outputs.should_release == 'true' }}
         with:

--- a/tools/skia_release/archive.py
+++ b/tools/skia_release/archive.py
@@ -24,6 +24,7 @@ def main():
   machine = common.machine()
   target = common.target()
   classifier = common.classifier()
+  enable_graphite_dawn = common.enable_graphite_dawn()
   out_bin = 'out/' + build_type + '-' + target + '-' + machine
 
   globs = [
@@ -82,6 +83,8 @@ def main():
       'third_party/externals/zlib/*.h',
       'third_party/icu/*.h',
   ]
+  if enable_graphite_dawn:
+    globs.append('third_party/externals/dawn/include/**/*')
 
   dist = 'Skia-' + version + '-' + target + '-' + build_type + '-' + machine + classifier + '.zip'
   print('> Writing', dist)


### PR DESCRIPTION
During the work on enabling Graphite Dawn on Windows, I noticed that some headers need to be included directly from Dawn

This PR adds them to the release archives